### PR TITLE
Memoize the pool key, created by string interpolation

### DIFF
--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -25,6 +25,7 @@ module ActiveRecordHostPool
     def __setobj__(spec)
       @spec = spec
       @config = spec.config.with_indifferent_access
+      @_pool_key = nil
     end
 
     def spec


### PR DESCRIPTION
Running a performance test recently, I noticed that `#_pool_key` generated a lot of objects:

```
6.72% 0.42% 24728.00 1545.00 0.00 23183.00  772       ActiveRecordHostPool::PoolProxy#_pool_key
            12373.00 3089.00 0.00  9284.00 3088/33571 Hash#[]
             6624.00 6950.00 0.00  1204.00  772/2279  Array#map
             1544.00 1544.00 0.00     0.00  772/828   Symbol#to_proc 
              772.00  772.00 0.00     0.00  772/1376  Array#join
```

I am fairly certain that it is safe to memoize `#_pool_key`. @osheroff, do you know?
