### PR TITLE
Override Delegator#respond_to_missing? to work with private methods

### DIFF
--- a/lib/active_record_host_pool/connection_proxy.rb
+++ b/lib/active_record_host_pool/connection_proxy.rb
@@ -37,6 +37,18 @@ module ActiveRecordHostPool
       __getobj__.respond_to?(m, include_private)
     end
 
+    def private_methods(all=true)
+      __getobj__.private_methods(all) | super
+    end
+
+    def send(symbol, *args, &blk)
+      if respond_to?(symbol, true) && !__getobj__.respond_to?(symbol, true)
+        super
+      else
+        __getobj__.send(symbol, *args, &blk)
+      end
+    end
+
     private
     def select(*args)
       @cx.__send__(:select, *args)

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -32,7 +32,8 @@ class ActiveRecordHostPoolTest < MiniTest::Unit::TestCase
     assert Test1.connection.is_a?(ActiveRecordHostPool::ConnectionProxy)
   end
 
-  def test_connection_proxy_handles_private_responds_to_calls
+  def test_connection_proxy_handles_private_methods
+    # Relies on connection.class returning the real class
     Test1.connection.class.class_eval do
       private
       def test_private_method
@@ -41,6 +42,8 @@ class ActiveRecordHostPoolTest < MiniTest::Unit::TestCase
     end
     assert Test1.connection.respond_to?(:test_private_method, true)
     refute Test1.connection.respond_to?(:test_private_method)
+    assert_includes(Test1.connection.private_methods, :test_private_method)
+    assert(Test1.connection.send(:test_private_method) == true)
   end
 
   def test_should_not_share_a_query_cache


### PR DESCRIPTION
The [`database_cleaner` gem uses `respond_to?`](https://github.com/DatabaseCleaner/database_cleaner/blob/master/lib/database_cleaner/active_record/transaction.rb#L39) to check if the connection responds to `rollback_transaction_records` which is a private method, which generates a warning each time the clear method is called (which is usually on every test), and also send to call the private method.

This PR overrides Delegator#respond_to_missing? and adds #send and #private_methods to work with private methods in the connection proxy.

/cc @osheroff @grosser @pschambacher @bquorning @adammw
