### PR TITLE
Ensures invalid connections are not re-used.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'wwtd/tasks'
 
 Rake::TestTask.new do |test|
   test.libs << 'lib'
-  test.pattern = 'test/test_arhp.rb'
+  test.pattern = 'test/test_*.rb'
   test.verbose = true
 end
 

--- a/gemfiles/ar_32.gemfile.lock
+++ b/gemfiles/ar_32.gemfile.lock
@@ -21,13 +21,6 @@ GEM
     arel (3.0.3)
     builder (3.0.4)
     bump (0.5.0)
-    columnize (0.8.9)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
     i18n (0.6.11)
     metaclass (0.0.4)
     mocha (1.1.0)
@@ -51,7 +44,6 @@ DEPENDENCIES
   active_record_host_pool!
   activerecord (= 3.2.17)
   bump
-  debugger
   mocha
   mysql2
   rake

--- a/gemfiles/ar_40.gemfile.lock
+++ b/gemfiles/ar_40.gemfile.lock
@@ -25,13 +25,6 @@ GEM
     arel (4.0.2)
     builder (3.1.4)
     bump (0.5.0)
-    columnize (0.8.9)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
     i18n (0.6.11)
     metaclass (0.0.4)
     minitest (4.7.5)
@@ -57,7 +50,6 @@ DEPENDENCIES
   active_record_host_pool!
   activerecord (= 4.0.4)
   bump
-  debugger
   mocha
   mysql2
   rake

--- a/gemfiles/ar_41.gemfile.lock
+++ b/gemfiles/ar_41.gemfile.lock
@@ -23,13 +23,6 @@ GEM
     arel (5.0.1.20140414130214)
     builder (3.2.2)
     bump (0.5.0)
-    columnize (0.8.9)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
     i18n (0.6.11)
     json (1.8.1)
     metaclass (0.0.4)
@@ -56,7 +49,6 @@ DEPENDENCIES
   active_record_host_pool!
   activerecord (= 4.1.0)
   bump
-  debugger
   mocha
   mysql2
   rake

--- a/gemfiles/ar_42.gemfile.lock
+++ b/gemfiles/ar_42.gemfile.lock
@@ -23,13 +23,6 @@ GEM
     arel (6.0.0.beta1)
     builder (3.2.2)
     bump (0.5.0)
-    columnize (0.8.9)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
     i18n (0.7.0.beta1)
     json (1.8.1)
     metaclass (0.0.4)
@@ -56,7 +49,6 @@ DEPENDENCIES
   active_record_host_pool!
   activerecord (= 4.2.0.beta2)
   bump
-  debugger
   mocha
   mysql2
   rake

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -12,6 +12,8 @@ require 'active_record_host_pool/connection_adapter_mixin'
 
 module ActiveRecordHostPool
   class PoolProxy < Delegator
+    include Kernel
+
     def initialize(spec)
       super(spec)
       @spec = spec

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -12,8 +12,6 @@ require 'active_record_host_pool/connection_adapter_mixin'
 
 module ActiveRecordHostPool
   class PoolProxy < Delegator
-    include Kernel
-
     def initialize(spec)
       super(spec)
       @spec = spec
@@ -42,7 +40,7 @@ module ActiveRecordHostPool
         if rescuable_errors.any? { |r| e.is_a?(r) }
           _connection_pools.delete(_pool_key)
         end
-        raise(e)
+        Kernel.raise(e)
       end
     end
 
@@ -87,6 +85,9 @@ module ActiveRecordHostPool
         end
         if Object.const_defined?("Mysql2")
           e << Mysql2::Error
+        end
+        if ActiveRecord.const_defined?("NoDatabaseError")
+          e << ActiveRecord::NoDatabaseError
         end
         e
       end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -118,31 +118,6 @@ class ActiveRecordHostPoolTest < MiniTest::Unit::TestCase
     assert_equal expected_database, current_database(switch_to_klass)
   end
 
-  # rake db:create uses a pattern where it tries to connect to a non-existant database.
-  # but then we had this left in the connection pool cache.
-  # It's also almost impossible to test at this level, so I'm stubbing out the test
-  def _test_connecting_to_wrong_db_first
-    pools = ActiveRecord::Base.connection_handler.connection_pools
-    if !pools.empty?
-      ActiveRecord::Base.connection_handler.connection_pools.values.first.send(:_connection_pools).clear
-      ActiveRecord::Base.connection_handler.connection_pools.clear
-    end
-
-    begin
-      eval <<-EOC
-        class TestNotThere < ActiveRecord::Base
-          establish_connection("test_host_1_db_not_there")
-        end
-      EOC
-    rescue Exception => e
-      assert e.message =~ /Unknown database/
-    end
-
-    Test1.establish_connection("test_host_1_db_1")
-    # assert it doesn't raise.
-    assert Test1.connection
-  end
-
   def teardown
     arhp_drop_databases
   end

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -16,7 +16,7 @@ class ActiveRecordHostPoolWrongDBTest < MiniTest::Unit::TestCase
     begin
       eval <<-EOC
         class TestNotThere < ActiveRecord::Base
-          establish_connection('test_host_1_db_not_there')
+          establish_connection(:test_host_1_db_not_there)
           connection
         end
       EOC
@@ -27,7 +27,7 @@ class ActiveRecordHostPoolWrongDBTest < MiniTest::Unit::TestCase
 
     assert reached_first_exception
 
-    Test1.establish_connection("test_host_1_db_1")
+    Test1.establish_connection(:test_host_1_db_1)
 
     begin
       Test1.connection

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -1,0 +1,44 @@
+require File.expand_path('helper', File.dirname(__FILE__))
+
+class ActiveRecordHostPoolWrongDBTest < MiniTest::Unit::TestCase
+  include ARHPTestSetup
+  def setup
+    arhp_create_models
+    ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
+  end
+
+  # rake db:create uses a pattern where it tries to connect to a non-existant database.
+  # but then we had this left in the connection pool cache.
+  def test_connecting_to_wrong_db_first
+    reached_first_exception = false
+    reached_second_exception = false
+
+    begin
+      eval <<-EOC
+        class TestNotThere < ActiveRecord::Base
+          establish_connection('test_host_1_db_not_there')
+          connection
+        end
+      EOC
+    rescue Exception => e
+      assert e.message =~ /Unknown database 'arhp_test_no_create'/
+      reached_first_exception = true
+    end
+
+    assert reached_first_exception
+
+    Test1.establish_connection("test_host_1_db_1")
+
+    begin
+      Test1.connection
+    rescue Exception => e
+      # If the pool is caching a bad connection, that connection will be used instead
+      # of the intended connection.
+      assert e.message !~ /Unknown database 'arhp_test_no_create'/
+      assert e.message =~ /Unknown database 'arhp_test_1'/
+      reached_second_exception = true
+    end
+
+    assert reached_second_exception
+  end
+end


### PR DESCRIPTION
This fixes rake db:create failing to create a database because the original connection references a database that doesn't exist. Upon
establishing a new connection to `:database => nil`, the original connection is re-used and throws the same error: "Unknown database".

~~An alternate fix would be modify the `_pool_key` to include `@config[:database]`, but that may diminish the value of this proxy.~~ :smile: 

References:
* https://github.com/rails/rails/blob/v3.2.21/activerecord/lib/active_record/railties/databases.rake#L120

/cc @osheroff @grosser @kencheeto 