### PR TITLE
Redux: Ensures invalid connections are not re-used

### DIFF
--- a/gemfiles/ar_32.gemfile.lock
+++ b/gemfiles/ar_32.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    active_record_host_pool (0.7.0)
+    active_record_host_pool (0.8.2)
       activerecord
 
 GEM

--- a/gemfiles/ar_40.gemfile.lock
+++ b/gemfiles/ar_40.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    active_record_host_pool (0.7.0)
+    active_record_host_pool (0.8.2)
       activerecord
 
 GEM

--- a/gemfiles/ar_41.gemfile.lock
+++ b/gemfiles/ar_41.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    active_record_host_pool (0.7.0)
+    active_record_host_pool (0.8.2)
       activerecord
 
 GEM

--- a/gemfiles/ar_42.gemfile.lock
+++ b/gemfiles/ar_42.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../
   specs:
-    active_record_host_pool (0.7.0)
+    active_record_host_pool (0.8.2)
       activerecord
 
 GEM

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -66,9 +66,15 @@ module ActiveRecordHostPool
     def disconnect!
       p = _connection_pool(false)
       return unless p
-      _connection_pool.disconnect!
-      _connection_pool.automatic_reconnect = true if _connection_pool.respond_to?(:automatic_reconnect=)
+      p.disconnect!
+      p.automatic_reconnect = true if p.respond_to?(:automatic_reconnect=)
       _clear_connection_proxy_cache
+    end
+
+    def automatic_reconnect=(value)
+      p = _connection_pool(false)
+      return unless p
+      p.automatic_reconnect = value if p.respond_to?(:automatic_reconnect=)
     end
 
     def clear_reloadable_connections!

--- a/test/database.yml
+++ b/test/database.yml
@@ -54,4 +54,3 @@ test_host_1_db_not_there:
   password:
   host: 127.0.0.1
   reconnect: true
-

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -3,7 +3,6 @@ require File.expand_path('helper', File.dirname(__FILE__))
 class ActiveRecordHostPoolWrongDBTest < MiniTest::Unit::TestCase
   include ARHPTestSetup
   def setup
-    arhp_create_models
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 
@@ -27,10 +26,10 @@ class ActiveRecordHostPoolWrongDBTest < MiniTest::Unit::TestCase
 
     assert reached_first_exception
 
-    Test1.establish_connection(:test_host_1_db_1)
+    TestNotThere.establish_connection(:test_host_1_db_1)
 
     begin
-      Test1.connection
+      TestNotThere.connection
     rescue Exception => e
       # If the pool is caching a bad connection, that connection will be used instead
       # of the intended connection.


### PR DESCRIPTION
Turns out my test didn't completely exercise the code the same way `rake
db:reset` exercises the code. Here's why the test was inadequate:

1. It runs `TestNotThere.establish_connection` followed by
`TestNotThere.connection`, which properly removes the invalid connection
to `arhp_test_no_create` from the connection pool.
2. Then it runs `Test1.establish_connection(:test_host_1_db_1)`
(database: `arhp_test_1`).
3. This invokes
https://github.com/rails/rails/blob/v3.2.21/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb#L136
4. Which invokes
https://github.com/rails/rails/blob/v3.2.21/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L429
5. Which invokes `self.__getobj__` https://github.com/zendesk/active_record_host_pool/blob/master/lib/active_record_host_pool/pool_proxy.rb#L21
6. Which re-instantiates the connection pool with the original spec: https://github.com/zendesk/active_record_host_pool/blob/master/lib/active_record_host_pool/pool_proxy.rb#L104
7. Which stores an invalid connection to `arhp_test_1`.
8. And as expected, when it runs `Test1.connection`, it gets an `Unknown
database 'arhp_test_1'` exception.

And here is where the use case breaks down:

1. It runs `TestNotThere.establish_connection` followed by
`TestNotThere.connection`, which properly removes the invalid connection
to `arhp_test_no_create` from the connection pool.
2. Then it runs `TestNotThere.establish_connection(:test_host_1_db_1)`
(database: `arhp_test_1`).
3. This invokes
https://github.com/rails/rails/blob/v3.2.21/activerecord/lib/active_record/connection_adapters/abstract/connection_specification.rb#L136
4. Which invokes
https://github.com/rails/rails/blob/v3.2.21/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L429
5. Which invokes `self.__getobj__` https://github.com/zendesk/active_record_host_pool/blob/master/lib/active_record_host_pool/pool_proxy.rb#L21
6. Which re-instantiates the connection pool with the original spec: https://github.com/zendesk/active_record_host_pool/blob/master/lib/active_record_host_pool/pool_proxy.rb#L104
7. Which stores an invalid connection to `arhp_test_no_create` (since the @spec is cached from 1)
8. And when it runs `TestNotThere.connection`, it gets an `Unknown
database 'arhp_test_no_create'` exception.

In conclusion, this PR will get us past the problem. Though, in all
seriousness, if there is an invalid connection and we manage to
hit an undefined method in `PoolProxy`, we will store that invalid
connection. It seems a longer term fix would be to check for connection
validity prior to storing/retrieving a connection.