### PR TITLE
Don't call #with_indifferent_access on the config

### DIFF
--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -15,7 +15,7 @@ module ActiveRecordHostPool
     def initialize(spec)
       super(spec)
       @spec = spec
-      @config = spec.config.with_indifferent_access
+      @config = spec.config
     end
 
     def __getobj__
@@ -24,7 +24,7 @@ module ActiveRecordHostPool
 
     def __setobj__(spec)
       @spec = spec
-      @config = spec.config.with_indifferent_access
+      @config = spec.config
       @_pool_key = nil
     end
 


### PR DESCRIPTION
When accessing a `HashWithIndifferentAccess` with a symbol key, a string is created by calling `to_s` on the symbol. If you call `#[:database]` 700 times in a row (yes, this happens), 700 separate instances of the string `"database"` will need garbage collection later on…

I looked at `ActiveRecord::ConnectionAdapters::ConnectionPool` source all the way from v2.2.0 up to the current master, and everywhere, the connection configuration is accessed using a symbol and not a string. So I don't see the need for calling `with_indifferent_access` on the configuration hash.

cc @osheroff @grosser 