### PR TITLE
Reliable active_record_shards / flexmaster slave selection

### DIFF
--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -104,7 +104,7 @@ module ActiveRecordHostPool
     end
 
     def _pool_key
-      @_pool_key ||= "#{@config[:host]}/#{@config[:port]}/#{@config[:socket]}/#{@config[:username]}"
+      @_pool_key ||= "#{@config[:host]}/#{@config[:port]}/#{@config[:socket]}/#{@config[:username]}/#{@config[:slave] && 'slave'}"
     end
 
     def _connection_pool(auto_create=true)

--- a/test/database.yml
+++ b/test/database.yml
@@ -8,6 +8,17 @@ test_host_1_db_1:
   host: <%= mysql.host %>
   reconnect: true
 
+# Mimic configurations as read by active_record_shards/ar_flexmaster
+test_host_1_db_1_slave:
+  adapter: mysql2
+  encoding: utf8
+  database: arhp_test_1_slave
+  username: <%= mysql.user %>
+  password: <%= mysql.password %>
+  host: <%= mysql.host %>
+  reconnect: true
+  slave: true
+
 test_host_1_db_2:
   adapter: mysql2
   encoding: utf8

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -27,6 +27,11 @@ module ARHPTestSetup
         establish_connection(:test_host_1_db_1)
       end
 
+      class Test1Slave < ActiveRecord::Base
+        self.table_name = "tests"
+        establish_connection(:test_host_1_db_1_slave)
+      end
+
       class Test2 < ActiveRecord::Base
         self.table_name =  "tests"
         establish_connection(:test_host_1_db_2)

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -24,6 +24,10 @@ class ActiveRecordHostPoolTest < Minitest::Test
     assert(Test4.connection.raw_connection != Test5.connection.raw_connection)
   end
 
+  def test_models_without_match_slave_status_should_not_share_a_connection
+    assert(Test1.connection.raw_connection != Test1Slave.connection.raw_connection)
+  end
+
   def test_should_select_on_correct_database
     action_should_use_correct_database(:select_all, "select 1")
   end


### PR DESCRIPTION
Currently when integrating with https://github.com/zendesk/active_record_shards if you don't specify different `:host` values in database.yml for the masters vs the slaves (because you're relying on flex master's `:hosts` entry to auto-detect the master), any `on_slave` calls will always return the existing connection pool for the master instead. This change introduces a conceptual coupling to ARS/FM, but does not impact anyone not using our garden of database gems, and is more simple than implementing a generic interface for this scenario. I stumbled on this when testing code in staging, but it could easily cause a major production issue if someone wasn't aware of the behavior.

/cc @steved @osheroff @bquorning @grosser