### PR TITLE
primary key issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem "mysql2", "~> 0.3.0"
-gem "activerecord", "3.2.17"
-gem "test-unit-minitest"
+gem "activerecord", "5.0.0"
 
 eval_gemfile 'gemfiles/common.rb'

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -10,7 +10,12 @@ module ActiveRecordHostPool
   module DatabaseSwitch
     def self.included(base)
       base.class_eval do
-        attr_accessor(:_host_pool_current_database)
+        attr_reader(:_host_pool_current_database)
+
+        def _host_pool_current_database=(database)
+          @_host_pool_current_database = database
+          @config[:database] = _host_pool_current_database if ActiveRecord::VERSION::MAJOR >= 5
+        end
 
         alias_method :execute_without_switching, :execute
         alias_method :execute, :execute_with_switching
@@ -64,7 +69,6 @@ module ActiveRecordHostPool
         log("select_db #{_host_pool_current_database}", "SQL") do
           clear_cache! if respond_to?(:clear_cache!)
           raw_connection.select_db(_host_pool_current_database)
-          @config[:database] = _host_pool_current_database if ActiveRecord::VERSION::MAJOR >= 5
         end
         @_cached_current_database = _host_pool_current_database
         @_cached_connection_object_id = @connection.object_id


### PR DESCRIPTION
patch @config[:database] sooner in the stack

I can't seem to get a test working that proves this, but later versions of the mysql2 adapter use `config[:database]` to generate SQL queries for stuff like `.primary_key`; so as soon as we access the connection at all we should slam the database into the configuration var.

@bquorning 