### PR TITLE
Just support mysql2, not mysql gem

### DIFF
--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -24,10 +24,10 @@ Gem::Specification.new do |s|
   s.license = "MIT"
 
   s.add_runtime_dependency("activerecord", ">= 3.2.0", "< 5.2")
+  s.add_runtime_dependency("mysql2")
 
   s.add_development_dependency("bump")
   s.add_development_dependency("mocha")
-  s.add_development_dependency("mysql2")
   s.add_development_dependency("phenix")
   s.add_development_dependency("rake", '>= 12.0.0')
   s.add_development_dependency('rubocop', '>= 0.55.0')

--- a/gemfiles/rails3.2.gemfile.lock
+++ b/gemfiles/rails3.2.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     active_record_host_pool (0.10.1)
       activerecord (>= 3.2.0, < 5.2)
+      mysql2
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     active_record_host_pool (0.10.1)
       activerecord (>= 3.2.0, < 5.2)
+      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -68,7 +69,6 @@ DEPENDENCIES
   bump
   byebug
   mocha
-  mysql2
   phenix
   rake (>= 12.0.0)
   rubocop (>= 0.55.0)

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     active_record_host_pool (0.10.1)
       activerecord (>= 3.2.0, < 5.2)
+      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -67,7 +68,6 @@ DEPENDENCIES
   bump
   byebug
   mocha
-  mysql2
   phenix
   rake (>= 12.0.0)
   rubocop (>= 0.55.0)

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     active_record_host_pool (0.10.1)
       activerecord (>= 3.2.0, < 5.2)
+      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -67,7 +68,6 @@ DEPENDENCIES
   bump
   byebug
   mocha
-  mysql2
   phenix
   rake (>= 12.0.0)
   rubocop (>= 0.55.0)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     active_record_host_pool (0.10.1)
       activerecord (>= 3.2.0, < 5.2)
+      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -68,7 +69,6 @@ DEPENDENCIES
   bump
   byebug
   mocha
-  mysql2
   phenix
   rake (>= 12.0.0)
   rubocop (>= 0.55.0)

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
-['mysql_adapter', 'mysql2_adapter'].each do |adapter|
-  begin
-    require "active_record/connection_adapters/#{adapter}"
-  rescue LoadError
-  end
-end
+require "active_record/connection_adapters/mysql2_adapter"
 
 module ActiveRecordHostPool
   module DatabaseSwitch
@@ -132,7 +127,4 @@ module ActiveRecord
   end
 end
 
-["MysqlAdapter", "Mysql2Adapter"].each do |k|
-  next unless ActiveRecord::ConnectionAdapters.const_defined?(k)
-  ActiveRecord::ConnectionAdapters.const_get(k).class_eval { include ActiveRecordHostPool::DatabaseSwitch }
-end
+ActiveRecord::ConnectionAdapters::Mysql2Adapter.include(ActiveRecordHostPool::DatabaseSwitch)

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -86,13 +86,7 @@ module ActiveRecordHostPool
 
     def rescuable_errors
       @rescuable_errors ||= begin
-        e = []
-        if Object.const_defined?("Mysql")
-          e << Mysql::Error
-        end
-        if Object.const_defined?("Mysql2")
-          e << Mysql2::Error
-        end
+        e = [Mysql2::Error]
         if ActiveRecord.const_defined?("NoDatabaseError")
           e << ActiveRecord::NoDatabaseError
         end


### PR DESCRIPTION
Last release of mysql gem was 5 years ago, and MysqlAdapter was removed in Rails 5.0. I doubt anyone uses active_record_host_pool together with the mysql gem.