### PR TITLE
Upgrade RuboCop

### DIFF
--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("mocha")
   s.add_development_dependency("phenix")
   s.add_development_dependency("rake", '>= 12.0.0')
-  s.add_development_dependency('rubocop', '>= 0.60.0')
+  s.add_development_dependency('rubocop', '~> 0.62.0')
   s.add_development_dependency("shoulda")
   s.add_development_dependency("wwtd")
 end


### PR DESCRIPTION
Versions < 0.62 are not compatible with Ruby 2.6: https://circleci.com/gh/zendesk/active_record_host_pool/287