### PR TITLE
Bump active_record_host_pool to 0.12.0

### DIFF
--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (0.11.0)
+    active_record_host_pool (0.12.0)
       activerecord (>= 4.2.0, < 6.0)
       mysql2
 

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (0.11.0)
+    active_record_host_pool (0.12.0)
       activerecord (>= 4.2.0, < 6.0)
       mysql2
 

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (0.11.0)
+    active_record_host_pool (0.12.0)
       activerecord (>= 4.2.0, < 6.0)
       mysql2
 

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (0.11.0)
+    active_record_host_pool (0.12.0)
       activerecord (>= 4.2.0, < 6.0)
       mysql2
 

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "0.11.0"
+  VERSION = "0.12.0"
 end


### PR DESCRIPTION
I'm looking at making some changes to this gem to support Rails 5.2.3 and in doing so noticed that there are a few changes on master that haven't been released yet.

 Releasing the diff between master and 0.11.0 in isolation.

Diff https://github.com/zendesk/active_record_host_pool/compare/v0.11.0...d75c570