### PR TITLE
Lock down OS images in tests to fix build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,32 @@ jobs:
     steps:
       *test_steps
 
+  # Ruby 2.6
+  test-2.6-with-4.2:
+    docker:
+      - image: circleci/ruby:2.6-stretch
+      - image: circleci/mysql:5.7-ram
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
+    steps:
+      *test_steps
+  test-2.6-with-5.1:
+    docker:
+      - image: circleci/ruby:2.6-stretch
+      - image: circleci/mysql:5.7-ram
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
+    steps:
+      *test_steps
+  test-2.6-with-5.2:
+    docker:
+      - image: circleci/ruby:2.6-stretch
+      - image: circleci/mysql:5.7-ram
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
+    steps:
+      *test_steps
+
   # RuboCop
   rubocop:
     docker:
@@ -119,5 +145,9 @@ workflows:
       - test-2.5-with-4.2
       - test-2.5-with-5.1
       - test-2.5-with-5.2
+
+      - test-2.6-with-4.2
+      - test-2.6-with-5.1
+      - test-2.6-with-5.2
 
       - rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   # Ruby 2.3
   test-2.3-with-4.2:
     docker:
-      - image: circleci/ruby:2.3
+      - image: circleci/ruby:2.3-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
@@ -25,7 +25,7 @@ jobs:
       *test_steps
   test-2.3-with-5.1:
     docker:
-      - image: circleci/ruby:2.3
+      - image: circleci/ruby:2.3-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
@@ -33,7 +33,7 @@ jobs:
       *test_steps
   test-2.3-with-5.2:
     docker:
-      - image: circleci/ruby:2.3
+      - image: circleci/ruby:2.3-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
@@ -43,7 +43,7 @@ jobs:
   # Ruby 2.4
   test-2.4-with-4.2:
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.4-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
@@ -51,7 +51,7 @@ jobs:
       *test_steps
   test-2.4-with-5.1:
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.4-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
@@ -59,7 +59,7 @@ jobs:
       *test_steps
   test-2.4-with-5.2:
     docker:
-      - image: circleci/ruby:2.4
+      - image: circleci/ruby:2.4-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
@@ -69,7 +69,7 @@ jobs:
   # Ruby 2.5
   test-2.5-with-4.2:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.5-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
@@ -77,7 +77,7 @@ jobs:
       *test_steps
   test-2.5-with-5.1:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.5-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
@@ -85,7 +85,7 @@ jobs:
       *test_steps
   test-2.5-with-5.2:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.5-stretch
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile


### PR DESCRIPTION
Our builds started failing for no obvious reason, turns out a new Debian image was released in July this year https://en.wikipedia.org/wiki/Debian_version_history#Debian_10_(Buster)

This patch locks down the Debian image to `stretch`, which is what we were using before. You can find the list of supported images for Circle CI here:
https://circleci.com/docs/2.0/circleci-images/#ruby

We can move when ready and not run into seemingly random failures next time an update gets rolled out. (Although it could be a couple of years 😅)