### PR TITLE
[CI] Update "mysql-client" to "default-mysql-client"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 test_steps: &test_steps
   - checkout
-  - run: sudo apt install -y mysql-client
+  - run: sudo apt install -y default-mysql-client
   - run: bundle install
   - run:
       name: Wait for MySQL to be ready


### PR DESCRIPTION
This package is outdated and no longer exists in newer Debian images, it'll be a blocker for us when we eventually move to Debian (buster)


https://packages.debian.org/stretch/mysql-client
> This is a transitional MySQL database that depends on default MySQL client metapackage. It can be safely removed.

https://packages.debian.org/stretch/default-mysql-client
> MySQL is a fast, stable and true multi-user, multi-threaded SQL database server. SQL (Structured Query Language) is the most popular database query language in the world. The main goals of MySQL are speed, robustness and ease of use.