### PR TITLE
[DRAFT] Update Debian image to 'buster'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
   # Ruby 2.4
   test-2.4-with-4.2:
     docker:
-      - image: circleci/ruby:2.4-stretch
+      - image: circleci/ruby:2.4-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
@@ -25,7 +25,7 @@ jobs:
       *test_steps
   test-2.4-with-5.1:
     docker:
-      - image: circleci/ruby:2.4-stretch
+      - image: circleci/ruby:2.4-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
@@ -33,7 +33,7 @@ jobs:
       *test_steps
   test-2.4-with-5.2:
     docker:
-      - image: circleci/ruby:2.4-stretch
+      - image: circleci/ruby:2.4-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
@@ -43,7 +43,7 @@ jobs:
   # Ruby 2.5
   test-2.5-with-4.2:
     docker:
-      - image: circleci/ruby:2.5-stretch
+      - image: circleci/ruby:2.5-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
@@ -51,7 +51,7 @@ jobs:
       *test_steps
   test-2.5-with-5.1:
     docker:
-      - image: circleci/ruby:2.5-stretch
+      - image: circleci/ruby:2.5-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
@@ -59,7 +59,7 @@ jobs:
       *test_steps
   test-2.5-with-5.2:
     docker:
-      - image: circleci/ruby:2.5-stretch
+      - image: circleci/ruby:2.5-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
@@ -69,7 +69,7 @@ jobs:
   # Ruby 2.6
   test-2.6-with-4.2:
     docker:
-      - image: circleci/ruby:2.6-stretch
+      - image: circleci/ruby:2.6-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails4.2.gemfile
@@ -77,7 +77,7 @@ jobs:
       *test_steps
   test-2.6-with-5.1:
     docker:
-      - image: circleci/ruby:2.6-stretch
+      - image: circleci/ruby:2.6-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.1.gemfile
@@ -85,7 +85,7 @@ jobs:
       *test_steps
   test-2.6-with-5.2:
     docker:
-      - image: circleci/ruby:2.6-stretch
+      - image: circleci/ruby:2.6-buster
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile


### PR DESCRIPTION
This PR is for investigating the issues with upgrading Debian to [version 10 (Buster)](https://en.wikipedia.org/wiki/Debian_version_history#Debian_10_(Buster)) which was released on the 9th of July 2019.

The following tests fail, causing all subsequent tests to fail

https://github.com/zendesk/active_record_host_pool/blob/5d7367f1db5501bdb8744bcad192ea4130236234/test/test_arhp.rb#L114-L147



<details>
<summary>Here's a snippet of the build output for easier viewing</summary>

The first error that causes all others to fail:
```
  1) Error:
ActiveRecordHostPoolTest#test_underlying_assumption_about_test_db:
ActiveRecord::StatementInvalid: Mysql2::Error: Lost connection to MySQL server during query: select DATABASE()
    /usr/local/bundle/gems/mysql2-0.4.10/lib/mysql2/client.rb:120:in `_query'
    /usr/local/bundle/gems/mysql2-0.4.10/lib/mysql2/client.rb:120:in `block in query'
    /usr/local/bundle/gems/mysql2-0.4.10/lib/mysql2/client.rb:119:in `handle_interrupt'
    /usr/local/bundle/gems/mysql2-0.4.10/lib/mysql2/client.rb:119:in `query'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:317:in `block in execute'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb:484:in `block in log'
    /usr/local/bundle/gems/activesupport-4.2.10/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb:478:in `log'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:317:in `execute'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/mysql2_adapter.rb:217:in `execute'
    /home/circleci/project/lib/active_record_host_pool/connection_adapter_mixin.rb:39:in `execute_with_switching'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/mysql2_adapter.rb:221:in `exec_query'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:356:in `select'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:32:in `select_all'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/query_cache.rb:70:in `select_all'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:38:in `select_one'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/database_statements.rb:43:in `select_value'
    /usr/local/lib/ruby/2.4.0/delegate.rb:83:in `method_missing'
    /home/circleci/project/test/helper.rb:61:in `current_database'
    /home/circleci/project/test/test_arhp.rb:146:in `test_underlying_assumption_about_test_db'
```

Subsequent errors
```
  2) Error:
ActiveRecordHostPoolTest#test_connection_returns_a_proxy:
ActiveRecord::StatementInvalid: Mysql2::Error: Unknown database 'arhp_test_2': select_db arhp_test_1
    /home/circleci/project/lib/active_record_host_pool/connection_adapter_mixin.rb:74:in `select_db'
    /home/circleci/project/lib/active_record_host_pool/connection_adapter_mixin.rb:74:in `block in _switch_connection'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb:484:in `block in log'
    /usr/local/bundle/gems/activesupport-4.2.10/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract_adapter.rb:478:in `log'
    /home/circleci/project/lib/active_record_host_pool/connection_adapter_mixin.rb:72:in `_switch_connection'
    /home/circleci/project/lib/active_record_host_pool/connection_adapter_mixin.rb:37:in `execute_with_switching'
    /usr/local/lib/ruby/2.4.0/delegate.rb:83:in `method_missing'
    /home/circleci/project/lib/active_record_host_pool/pool_proxy.rb:121:in `_connection_proxy_for'
    /home/circleci/project/lib/active_record_host_pool/pool_proxy.rb:39:in `connection'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_adapters/abstract/connection_pool.rb:571:in `retrieve_connection'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_handling.rb:113:in `retrieve_connection'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/connection_handling.rb:87:in `connection'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/migration.rb:648:in `connection'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/migration.rb:664:in `block in method_missing'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/migration.rb:634:in `block in say_with_time'
    /usr/local/lib/ruby/2.4.0/benchmark.rb:293:in `measure'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/migration.rb:634:in `say_with_time'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/migration.rb:654:in `method_missing'
    /home/circleci/project/test/schema.rb:5:in `block in <top (required)>'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/schema.rb:41:in `instance_eval'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/schema.rb:41:in `define'
    /usr/local/bundle/gems/activerecord-4.2.10/lib/active_record/schema.rb:61:in `define'
    /home/circleci/project/test/schema.rb:4:in `<top (required)>'
    /usr/local/bundle/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
    /usr/local/bundle/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `block in load'
    /usr/local/bundle/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
    /usr/local/bundle/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
    /usr/local/bundle/gems/phenix-0.5.0/lib/phenix.rb:55:in `populate_database'
    /usr/local/bundle/gems/phenix-0.5.0/lib/phenix.rb:48:in `block in create_databases'
    /usr/local/bundle/gems/phenix-0.5.0/lib/phenix.rb:70:in `block in for_each_database'
    /usr/local/bundle/gems/phenix-0.5.0/lib/phenix.rb:67:in `each'
    /usr/local/bundle/gems/phenix-0.5.0/lib/phenix.rb:67:in `for_each_database'
    /usr/local/bundle/gems/phenix-0.5.0/lib/phenix.rb:45:in `create_databases'
    /usr/local/bundle/gems/phenix-0.5.0/lib/phenix.rb:29:in `rise!'
    /home/circleci/project/test/test_arhp.rb:8:in `setup'
```
</details>

