### PR TITLE
Add support for Rails 5.2.3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,6 +24,14 @@ You need a local user called 'john-doe'.
     GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX  ON *.* TO 'john-doe'@'localhost';
     FLUSH PRIVILEGES;
 
+With mysql running locally, run
+
+    BUNDLE_GEMFILE=gemfiles/rails5.2.gemfile bundle exec rake test
+
+ Or
+
+    BUNDLE_GEMFILE=gemfiles/rails5.2.gemfile ruby test/test_arhp.rb --seed 19911 --verbose
+
 ## Copyright
 
 Copyright (c) 2011 Zendesk. See MIT-LICENSE for details.

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -103,6 +103,13 @@ module ActiveRecordHostPool
       return unless p
 
       p.discard!
+
+      # All connections in the pool (even if they're currently
+      # leased!) have just been discarded, along with the pool itself.
+      # Any further interaction with the pool (except #spec and #schema_cache)
+      # is undefined.
+      # Remove the connection for the given key so a new one can be created in its place
+      _connection_pools.delete(_pool_key)
     end
 
     private

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -84,6 +84,27 @@ module ActiveRecordHostPool
       _clear_connection_proxy_cache
     end
 
+    def release_connection(owner_thread = Thread.current)
+      p = _connection_pool(false)
+      return unless p
+
+      p.release_connection(owner_thread)
+    end
+
+    def flush!
+      p = _connection_pool(false)
+      return unless p
+
+      p.flush!
+    end
+
+    def discard!
+      p = _connection_pool(false)
+      return unless p
+
+      p.discard!
+    end
+
     private
 
     def rescuable_errors


### PR DESCRIPTION
Upon upgrading to Rails 5.2.3 and using v0.11.0 of this gem I received exceptions when a forked process attempted to communicate to the database. 

I could reproduce the behaviour with `config.cache_classes = config.eager_load = true`  set in my `config/environment/development.rb` and executing  `rails runner "Process.fork { ActiveRecord::Base.connected? }"`

Rails has modified the way it handles database connections in
 * rails/rails#31173 
 * rails/rails#28057 
 * rails/rails#31221

This patch adds supports to this gem for Rails 5.2.3 with the following 
 * Don't auto-create connection if nil on methods 5916c96
 * Clear entry from PoolProxy when Rails discards a ConnectionPool 460b4d1