### PR TITLE
Rails 6 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,6 +70,14 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
     steps:
       *test_steps
+  test-2.5-with-6.0:
+    docker:
+      - image: circleci/ruby:2.5-stretch
+      - image: circleci/mysql:5.7-ram
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails6.0.gemfile
+    steps:
+      *test_steps
 
   # Ruby 2.6
   test-2.6-with-4.2:
@@ -94,6 +102,14 @@ jobs:
       - image: circleci/mysql:5.7-ram
     environment:
       BUNDLE_GEMFILE: gemfiles/rails5.2.gemfile
+    steps:
+      *test_steps
+  test-2.6-with-6.0:
+    docker:
+      - image: circleci/ruby:2.6-stretch
+      - image: circleci/mysql:5.7-ram
+    environment:
+      BUNDLE_GEMFILE: gemfiles/rails6.0.gemfile
     steps:
       *test_steps
 
@@ -125,9 +141,11 @@ workflows:
       - test-2.5-with-4.2
       - test-2.5-with-5.1
       - test-2.5-with-5.2
+      - test-2.5-with-6.0
 
       - test-2.6-with-4.2
       - test-2.6-with-5.1
       - test-2.6-with-5.2
+      - test-2.6-with-6.0
 
       - rubocop

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 _does not yet_ adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Rails 6.0.x. (https://github.com/zendesk/active_record_host_pool/pull/53)
 
 ## [0.13.0] - 2019-08-26
 ### Added

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.test_files = ["test/database.yml", "test/helper.rb", "test/schema.rb", "test/test_arhp.rb"]
   s.license = "MIT"
 
-  s.add_runtime_dependency("activerecord", ">= 4.2.0", "< 6.0")
+  s.add_runtime_dependency("activerecord", ">= 4.2.0", "< 6.1")
   s.add_runtime_dependency("mysql2")
 
   s.add_development_dependency("bump")

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_host_pool (0.13.0)
-      activerecord (>= 4.2.0, < 6.0)
+      activerecord (>= 4.2.0, < 6.1)
       mysql2
 
 GEM

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_host_pool (0.13.0)
-      activerecord (>= 4.2.0, < 6.0)
+      activerecord (>= 4.2.0, < 6.1)
       mysql2
 
 GEM

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_host_pool (0.13.0)
-      activerecord (>= 4.2.0, < 6.0)
+      activerecord (>= 4.2.0, < 6.1)
       mysql2
 
 GEM

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 6.0.0'
+gem 'mysql2', '>= 0.4.4'
+
+eval_gemfile 'common.rb'

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -8,47 +8,44 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.2.11.1)
-      activesupport (= 4.2.11.1)
-      builder (~> 3.1)
-    activerecord (4.2.11.1)
-      activemodel (= 4.2.11.1)
-      activesupport (= 4.2.11.1)
-      arel (~> 6.0)
-    activesupport (4.2.11.1)
-      i18n (~> 0.7)
+    activemodel (6.0.2.1)
+      activesupport (= 6.0.2.1)
+    activerecord (6.0.2.1)
+      activemodel (= 6.0.2.1)
+      activesupport (= 6.0.2.1)
+    activesupport (6.0.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
       minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    arel (6.0.4)
+      zeitwerk (~> 2.2)
     ast (2.4.0)
-    builder (3.2.4)
     bump (0.9.0)
     byebug (11.1.1)
     concurrent-ruby (1.1.6)
-    i18n (0.9.5)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     minitest (5.14.0)
     mocha (1.11.2)
-    mysql2 (0.4.10)
+    mysql2 (0.5.3)
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
     phenix (0.6.0)
       activerecord (>= 4.2, < 6.1)
       bundler
+    powerpack (0.1.2)
     rainbow (3.0.0)
     rake (13.0.1)
-    rexml (3.2.4)
-    rubocop (0.80.0)
+    rubocop (0.62.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
-      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.1)
     shoulda (3.6.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -59,21 +56,22 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.4.1)
+    zeitwerk (2.2.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   active_record_host_pool!
-  activerecord (~> 4.2.0)
+  activerecord (~> 6.0.0)
   bump
   byebug
   mocha
-  mysql2 (>= 0.3.13, < 0.5)
+  mysql2 (>= 0.4.4)
   phenix
   rake (>= 12.0.0)
-  rubocop (~> 0.80.0)
+  rubocop (~> 0.62.0)
   shoulda
 
 BUNDLED WITH

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -85,22 +85,21 @@ module ActiveRecordHostPool
   end
 end
 
+# rubocop:disable Lint/DuplicateMethods
 module ActiveRecord
   module ConnectionAdapters
     class ConnectionHandler
-      if ActiveRecord::VERSION::MAJOR == 5
-        if ActiveRecord::VERSION::MINOR == 0
-          raise "Unsupported version of Rails (v#{ActiveRecord::VERSION::STRING})"
-        else
-          def establish_connection(spec)
-            resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(Base.configurations)
-            spec = resolver.spec(spec)
+      case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+      when '5.1', '5.2', '6.0'
 
-            owner_to_pool[spec.name] = ActiveRecordHostPool::PoolProxy.new(spec)
-          end
+        def establish_connection(spec)
+          resolver = ConnectionAdapters::ConnectionSpecification::Resolver.new(Base.configurations)
+          spec = resolver.spec(spec)
+
+          owner_to_pool[spec.name] = ActiveRecordHostPool::PoolProxy.new(spec)
         end
 
-      elsif ActiveRecord::VERSION::MAJOR == 4
+      when '4.2'
 
         def establish_connection(owner, spec)
           @class_to_pool.clear
@@ -116,5 +115,6 @@ module ActiveRecord
     end
   end
 end
+# rubocop:enable Lint/DuplicateMethods
 
 ActiveRecord::ConnectionAdapters::Mysql2Adapter.include(ActiveRecordHostPool::DatabaseSwitch)


### PR DESCRIPTION
It looks like Rails 6 works with the same `#establish_connection` implementation as for Rails 5.2.