### PR TITLE
Fix release_connection rails 4.2 compatibility

### DIFF
--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -84,11 +84,11 @@ module ActiveRecordHostPool
       _clear_connection_proxy_cache
     end
 
-    def release_connection(owner_thread = Thread.current)
+    def release_connection(*args)
       p = _connection_pool(false)
       return unless p
 
-      p.release_connection(owner_thread)
+      p.release_connection(*args)
     end
 
     def flush!

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -163,6 +163,13 @@ class ActiveRecordHostPoolTest < Minitest::Test
     assert_equal expected_database, current_database(switch_to_klass)
   end
 
+  def test_release_connection
+    pool = ActiveRecord::Base.connection_pool
+    conn = pool.connection
+    pool.expects(:checkin).with(conn)
+    pool.release_connection
+  end
+
   private
 
   def assert_action_uses_correct_database(action, sql)


### PR DESCRIPTION
- In #48, `release_connection` was overridden for Rails 5 compatibility.
- This causes connection leakage in Rails 4.2, which uses `Thread.current.object_id` ([source](https://github.com/rails/rails/blob/v4.2.11.1/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L442)) as the key, unlike Rails 5+ which uses `Thread.current` ([source](https://github.com/rails/rails/blob/v5.2.4.2/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L401)) as the key.
- Override `release_connection` in an argument-agnostic manner to fix this.

@bquorning @pschambacher @grosser 