### PR TITLE
Bump to v1.0.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [1.0.1] - 2020-03-30
+### Fixed
+- Fix connection leakage when calling `release_connection` on pre-Rails 5 applications. (https://github.com/zendesk/active_record_host_pool/pull/58)
+
 ## [1.0.0] - 2020-02-25
 ### Added
 - Support for Rails 6.0.x. (https://github.com/zendesk/active_record_host_pool/pull/53)

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.0)
+    active_record_host_pool (1.0.1)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.0)
+    active_record_host_pool (1.0.1)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.0)
+    active_record_host_pool (1.0.1)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.0)
+    active_record_host_pool (1.0.1)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.0)
+    active_record_host_pool (1.0.1)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Fixed: Fix connection leakage when calling `release_connection` on pre-Rails 5 applications: #58
