### PR TITLE
Rails 6.0+: Include database name in the criteria for pooling connections

### DIFF
--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -129,7 +129,16 @@ module ActiveRecordHostPool
     end
 
     def _pool_key
-      @_pool_key ||= "#{@config[:host]}/#{@config[:port]}/#{@config[:socket]}/#{@config[:username]}/#{@config[:slave] && 'slave'}"
+      @_pool_key ||= begin
+        [
+          @config[:host],
+          @config[:port],
+          @config[:socket],
+          @config[:username],
+          @config[:database],
+          @config[:slave] ? 'slave' : ''
+        ].join('/')
+      end
     end
 
     def _connection_pool(auto_create = true)

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,5 +1,5 @@
 <% mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306') %>
-test_host_1_db_1:
+test_host_1_db_1: &test_host_1_db_1
   adapter: mysql2
   encoding: utf8
   database: arhp_test_1
@@ -28,7 +28,7 @@ test_host_1_db_2:
   host: <%= mysql.host %>
   reconnect: true
 
-test_host_2_db_3:
+test_host_2_db_3: &test_host_2_db_3
   adapter: mysql2
   encoding: utf8
   database: arhp_test_3
@@ -66,3 +66,9 @@ test_host_1_db_not_there:
   password: <%= mysql.password %>
   host: <%= mysql.host %>
   reconnect: true
+
+test_host_1_db_1_shard_1:
+  <<: *test_host_1_db_1
+
+test_host_2_db_3_shard_1:
+  <<: *test_host_2_db_3

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -54,6 +54,14 @@ module ARHPTestSetup
         self.table_name = "tests"
         establish_connection(:test_host_2_db_5)
       end
+
+      class Test1Shard1 < ::ActiveRecord::Base
+        establish_connection(:test_host_1_db_1_shard_1)
+      end
+
+      class Test3Shard1 < ::ActiveRecord::Base
+        establish_connection(:test_host_2_db_3_shard_1)
+      end
     RUBY
   end
 

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -2,7 +2,7 @@
 
 require_relative 'helper'
 ActiveRecord::Schema.define(version: 1) do
-  create_table 'tests' do |t|
+  create_table 'tests', force: true do |t|
     t.string   'val'
   end
 end


### PR DESCRIPTION
# What does this PR do?

This PR includes the database name in the criteria for pooling connection in order to prevent connection pools to contain connections for different databases.

Otherwise it is possible for connections to different databases to share underlying MySQL connections. This is problematic as simply referencing the connection via the ActiveRecordHostPool::ConnectionProxy can change the current database out from under another connection.  

## Alternate to PR #61 

This PR is an alternate to PR #61.

That PR resolves the surface-level issue, but does not fix the underlying general issue which keeps an optimization in `active_record_host_pool` to remain in place which reduces the number of DB connections needed. This PR fixes the general underlying issue, but will increase database connections as a result.

## Illustrating the issue in an application

Consider using this gem and [`active_record_shards`](http://github.com/zendesk/active_record_shards) gem. You may have this set up:

```ruby
class UnsharedModel < ::ActiveRecord::Base
  not_sharded
end

ActiveRecord::Base.default_shard = 1
ActiveRecord::Base.connection.cache do
  UnshardedModel.create!(name: "Soren")
end
```

Without this fix the above would generate this error in Rails 6.0:

> ActiveRecord::StatementInvalid:
>   Mysql2::Error: Table 'my_database_test_shard_1.unsharded_models' doesn't exist

The error illustrates that even though `UnshardedModel` is not to be shared that during the operation of creating the record the database was switched back to the default shared database, `my_database_test_shard_1`.

## Context of this issue

This issue presented itself with a combination of using active_record_shards and active_record_host_pool. It was representing the sharded and unsharded database connections within the same connection pool. This problem did not manifest itself until Rails 6 when cache clearing for cache dirtying operations—e.g. insert, update, truncate, delete, etc—was updated to loop over the app's connection handlers, connection pools to search for currently active connections. 

  This happens [mid-operation (inside of ActiveRecord::ConnectionAdapters::Mysql2Adapter instance)](https://github.com/rails/rails/blob/e6c6f1b4115495b27a2d32a4bd5c95256db695b1/activerecord/lib/active_record/connection_adapters/abstract/query_cache.rb#L21) just before the operation is carried out. The result was that referencing the connection was changing the currently selected database and it was not being restored. This led to issues where the operation would try to be carried out on a different database that did not have the same tables/columns.

##  References

The problematic line that causes the database to switch is: https://github.com/zendesk/active_record_host_pool/blob/981fdeb8dfa52f390bd91471adc19049283c6fb8/lib/active_record_host_pool/connection_proxy.rb#L16

The change in Rails 6 that exercised a code path to expose this surface the issue: https://github.com/rails/rails/pull/35089/files#diff-193e6e4a86bf5d360a5001bce59334cbR180-R186

## Why this fix?

Connection (aka resource) pools are generally used to recycle connections that can be used within the same context. For the purposes of what ActiveRecordHostPool does context seems to mean databases with the same tables/columns/etc.

However, connections that point to different databases on the same host are unlikely to represent similar contexts. This change-set moves to consider them entirely different contexts. By doing so this circumvents any issues where higher-level connections that point to different databases will share an underlying mysql connection.

## Benefits of the previous implementation

Prior to this change, the implementation reduced the number of connections by switching the database using SELECT DATABASE SQL statements.

This has worked for nearly a decade, but has always been open to the issue of one connection changing the database out from under an operation assuming a different database. It just so happens that Rails 6 begins to exercise a code path that exposes this issue.

## Consequences of the previous implementation

The potential for this bug to exist.

## Benefits of the updated implementation

By pooling connections together with criteria that ensures interchangeable contexts we eliminate the chance for this issue to exist.

## Consequences of the updated implementation

This will increase the number of connection pools. Previously it was based on the number of unique database combinations of host+port+socket+username+slave. Now, it will also include database name.

This will also likely increase the number of open database connections as these pools will now each have their own number of connections limit to manage.

## Risks

**Medium** because this will likely increase the number of open/active connections. 