### PR TITLE
Rails 6: Patch ActiveRecord::Base.clear_query_caches_for_current_thread 

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Fixed
+- Fix unintended connection switching while clearing query cache in Rails 6.0. (https://github.com/zendesk/active_record_host_pool/pull/61)
+
 ## [1.0.1] - 2020-03-30
 ### Fixed
 - Fix connection leakage when calling `release_connection` on pre-Rails 5 applications. (https://github.com/zendesk/active_record_host_pool/pull/58)

--- a/lib/active_record_host_pool.rb
+++ b/lib/active_record_host_pool.rb
@@ -4,6 +4,7 @@ require 'active_record'
 require 'active_record/base'
 require 'active_record/connection_adapters/abstract_adapter'
 
+require 'active_record_host_pool/clear_query_cache_patch'
 require 'active_record_host_pool/connection_proxy'
 require 'active_record_host_pool/pool_proxy'
 require 'active_record_host_pool/connection_adapter_mixin'

--- a/lib/active_record_host_pool/clear_query_cache_patch.rb
+++ b/lib/active_record_host_pool/clear_query_cache_patch.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+if ActiveRecord.version >= Gem::Version.new('6.0')
+  module ActiveRecordHostPool
+    # ActiveRecord 6.0 introduced multiple database support. With that, an update
+    # has been made in https://github.com/rails/rails/pull/35089 to ensure that
+    # all query caches are cleared across connection handlers and pools. If you
+    # write on one connection, the other connection will have the update that
+    # occurred.
+    #
+    # This broke ARHP which implements its own pool, allowing you to access
+    # multiple databases with the same connection (e.g. 1 connection for 100
+    # shards on the same server).
+    #
+    # This patch maintains the reference to the database during the cache clearing
+    # to ensure that the database doesn't get swapped out mid-way into an
+    # operation.
+    #
+    # This is a private Rails API and may change in future releases as they're
+    # actively working on sharding in Rails 6 and above.
+    module ClearQueryCachePatch
+      def clear_query_caches_for_current_thread
+        host_pool_current_database_was = connection.unproxied._host_pool_current_database
+        super
+      ensure
+        # restore in case clearing the cache changed the database
+        connection.unproxied._host_pool_current_database = host_pool_current_database_was
+      end
+    end
+  end
+
+  ActiveRecord::Base.singleton_class.prepend ActiveRecordHostPool::ClearQueryCachePatch
+end

--- a/test/database.yml
+++ b/test/database.yml
@@ -66,3 +66,12 @@ test_host_1_db_not_there:
   password: <%= mysql.password %>
   host: <%= mysql.host %>
   reconnect: true
+
+test_host_1_db_shard:
+  adapter: mysql2
+  encoding: utf8
+  database: arhp_test_1_shard
+  username: <%= mysql.user %>
+  password: <%= mysql.password %>
+  host: <%= mysql.host %>
+  reconnect: true

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -2,7 +2,15 @@
 
 require_relative 'helper'
 ActiveRecord::Schema.define(version: 1) do
-  create_table 'tests' do |t|
+  create_table 'tests', force: true do |t|
     t.string   'val'
+  end
+
+  # Add a table only the shard database will have. Conditional
+  # exists since Phenix loads the schema file for every database.
+  if ActiveRecord::Base.connection.current_database == 'arhp_test_1_shard'
+    create_table 'test1_shards' do |t|
+      t.string 'name'
+    end
   end
 end


### PR DESCRIPTION
# What does this PR do?

This PR patches `ActiveRecord::Base.clear_query_caches_for_current_thread` to restore the connection's database after it is done. Otherwise it's possible for a Mysql2Adapter instance's database to be changed out from under it during an operation (e.g. insert, update, delete, truncate, etc).

## Alternate to PR #60 

This PR is an alternate to PR #60. 

That PR resolves the general issue but loses out on an optimization to reduce the number of DB connections needed. This PR keeps the optimization, but leave the risk that this issue could show up again if new code paths are introduced to ActiveRecord or in gems that exercise the problematic code path.

## Illustrating the issue in an application

Consider using this gem and [`active_record_shards`](http://github.com/zendesk/active_record_shards) gem. You may have this set up:

```ruby
class UnsharedModel < ::ActiveRecord::Base
  not_sharded
end

ActiveRecord::Base.default_shard = 1
ActiveRecord::Base.connection.cache do
  UnshardedModel.create!(name: "Soren")
end
```

## Context of this issue

This issue presented itself with a combination of using active_record_shards and `active_record_host_pool`. It was representing the sharded and unsharded database connections within the same connection pool. This problem did not manifest itself until Rails 6 when cache clearing for cache dirtying operations—e.g. insert, update, truncate, delete, etc—was updated to loop over the app's connection handlers, connection pools to search for currently active connections.

This happens [mid-operation (inside of ActiveRecord::ConnectionAdapters::Mysql2Adapter instance)](https://github.com/rails/rails/pull/35089/files#diff-c666cf7fe697634c32bc09b80a4d8787R20) just before the operation is carried out. The result was that referencing the connection was changing the currently selected database and it was not being restored. This led to issues where the operation would try to be carried out on a different database that did not have the same tables/columns.

It is important to note that this issue existed in active_record_host_pool for years, but no code paths exercised it. The assumption that connections would not be re-referenced from within an operation on a connection was safe for years until ActiveRecord 6.

## Why this fix?

The active_record_host_pool library is optimized to reduce the number of database connections by pooling them by host/port/socket/user/slave. This means that different databases on the same host will use the same connection pool. This requires that this library provide a mechanism for selecting the correct database when executing queries.

This fix maintains that optimization and fixes the currently known problematic code path introduced in ActiveRecord 6.

## Benefits of this change

Preserves host pool optimization.

## Consequences of this change

This does not fix the issue, it just fixes the one spot where we know ActiveRecord 6.0 can expose it.

## References

The problematic line that causes the database to switch is: https://github.com/zendesk/active_record_host_pool/blob/981fdeb8dfa52f390bd91471adc19049283c6fb8/lib/active_record_host_pool/connection_proxy.rb#L16

The change in Rails 6 that exercised a code path to expose this surface the issue: https://github.com/rails/rails/pull/35089/files#diff-193e6e4a86bf5d360a5001bce59334cbR180-R186

For an alternate solution see: https://github.com/zendesk/active_record_host_pool/pull/60