### PR TITLE
Make ARHP's connection switching thread safe

### DIFF
--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -6,13 +6,6 @@ module ActiveRecordHostPool
   module DatabaseSwitch
     def self.included(base)
       base.class_eval do
-        attr_reader(:_host_pool_current_database)
-
-        def _host_pool_current_database=(database)
-          @_host_pool_current_database = database
-          @config[:database] = _host_pool_current_database if ActiveRecord::VERSION::MAJOR >= 5
-        end
-
         alias_method :execute_without_switching, :execute
         alias_method :execute, :execute_with_switching
 
@@ -25,11 +18,6 @@ module ActiveRecordHostPool
         alias_method :disconnect_without_host_pooling!, :disconnect!
         alias_method :disconnect!, :disconnect_with_host_pooling!
       end
-    end
-
-    def initialize(*)
-      @_cached_current_database = nil
-      super
     end
 
     def execute_with_switching(*args)
@@ -54,33 +42,108 @@ module ActiveRecordHostPool
     end
 
     def disconnect_with_host_pooling!
-      @_cached_current_database = nil
-      @_cached_connection_object_id = nil
+      self._cached_connection_object_id = nil
       disconnect_without_host_pooling!
+    end
+
+    def _host_pool_current_database
+      _ahrp_storage[:_host_pool_current_database]
+    end
+
+    def _host_pool_current_database=(database)
+      _ahrp_storage[:_host_pool_current_database] = database
+      @config[:database] = _host_pool_current_database
     end
 
     private
 
-    attr_accessor :_no_switch
+    attr_accessor :_cached_connection_object_id, :_cached_current_database, :_no_switch
+
+    def _ahrp_storage
+      @_ahrp_storage ||= {}
+    end
+
+    def _ahrp_fetch_database_to_switch_to
+      database_name = _host_pool_current_database
+      if database_name != _cached_current_database || connection.object_id != _cached_connection_object_id
+        database_name
+      end
+    end
 
     def _switch_connection
-      if _host_pool_current_database &&
-         (
-           (_host_pool_current_database != @_cached_current_database) ||
-           @connection.object_id != @_cached_connection_object_id
-         )
-        log("select_db #{_host_pool_current_database}", "SQL") do
+      database_name = _ahrp_fetch_database_to_switch_to
+      if database_name
+        log("select_db #{database_name}", "SQL") do
           clear_cache! if respond_to?(:clear_cache!)
-          raw_connection.select_db(_host_pool_current_database)
+          raw_connection.select_db(database_name)
         end
-        @_cached_current_database = _host_pool_current_database
-        @_cached_connection_object_id = @connection.object_id
+        self._cached_connection_object_id = @connection.object_id
       end
     end
 
     # prevent different databases from sharing the same query cache
     def cache_sql(sql, *args)
       super(_host_pool_current_database.to_s + "/" + sql, *args)
+    end
+  end
+
+  module PerThreadHashAccess
+    # PerThreadHashAccess.module_for(...) returns a module which scopes hash accessor methods
+    # to the given connection_id with thread-local values. It uses `super` as a fallback. This is to
+    # make access to the config object on a ActiveRecord::ConnectionAdapters::Mysql2Adapter
+    # thread-safe.
+    #
+    # Because AHRP shares the connection across members of its connection pool it is possible for
+    # multiple threads be simultaneously trying to talk to the database.
+    def self.module_for(connection_id)
+      Module.new do
+        define_method(:[]=) do |key, value|
+          _ahrp_storage[key] = value
+        end
+
+        define_method(:[]) do |key|
+          if _ahrp_storage.key?(key)
+            _ahrp_storage[key]
+          else
+            _ahrp_storage[key] = super(key)
+          end
+        end
+
+        define_method(:fetch) do |*args, &blk|
+          key, = args
+          _ahrp_storage.fetch(key) do
+            _ahrp_storage[key] = super(*args, &blk)
+          end
+        end
+
+        private
+
+        define_method(:_ahrp_storage) do
+          ThreadSafe.storage[connection_id]
+        end
+      end
+    end
+  end
+
+  module ThreadSafe
+    def self.storage
+      Thread.current[:active_record_host_pool] ||= Hash.new { |hash, key| hash[key] = {} }
+    end
+
+    def initialize(*)
+      super
+
+      @config.singleton_class.prepend PerThreadHashAccess.module_for(@connection.object_id)
+    end
+
+    private
+
+    def _ahrp_storage
+      ThreadSafe.storage[_cached_connection_object_id]
+    end
+
+    def _ahrp_fetch_database_to_switch_to
+      _host_pool_current_database
     end
   end
 end
@@ -118,3 +181,4 @@ end
 # rubocop:enable Lint/DuplicateMethods
 
 ActiveRecord::ConnectionAdapters::Mysql2Adapter.include(ActiveRecordHostPool::DatabaseSwitch)
+ActiveRecord::ConnectionAdapters::Mysql2Adapter.include(ActiveRecordHostPool::ThreadSafe)

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -134,7 +134,7 @@ class ActiveRecordHostPoolTest < Minitest::Test
     Test1.first
 
     # which is the "default" DB to connect to?
-    first_db = Test1.connection.unproxied.instance_variable_get(:@_cached_current_database)
+    first_db = Test1.connection.unproxied.current_database
     puts "\nOk, we started on #{first_db}" if debug_me
 
     switch_to_klass = case first_db

--- a/test/test_arhp_thread_safety.rb
+++ b/test/test_arhp_thread_safety.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class ActiveRecordHostPoolTest < Minitest::Test
+  include ARHPTestSetup
+
+  def setup
+    Phenix.rise!
+    arhp_create_models
+    change_databases_across_two_threads
+  end
+
+  def teardown
+    Phenix.burn!
+  end
+
+  # When the implementation is not thread-safe the below query will try to execute the query on the
+  # "some_other_database" which doesn't exist and this will blow up.
+  def test_executing_query_is_not_impacted_by_another_thread_switching_databases
+    connection.execute('select count(*) from tests')
+  end
+
+  # Sanity check that the databases in use per thread are distinct.
+  def test_databases_are_thread_local
+    assert_equal 'arhp_test_1', database_values.database_in_use_on_main_thread
+    assert_equal 'some_other_database', database_values.database_in_use_on_child_thread
+  end
+
+  def test_connection_adapter_internal_database_is_thread_local
+    assert_equal 'arhp_test_1', database_values.database_config_in_use_on_main_thread
+    assert_equal 'some_other_database', database_values.database_config_on_child_thread
+  end
+
+  private
+
+  def connection
+    @connection ||= Test1.connection.unproxied
+  end
+
+  def database_values
+    @database_values ||= OpenStruct.new(
+      database_in_use_on_child_thread: nil,
+      database_config_on_child_thread: nil,
+      database_in_use_on_main_thread: nil,
+      database_config_on_main_thread: nil
+    )
+  end
+
+  def change_databases_across_two_threads
+    connection._host_pool_current_database = 'arhp_test_1'
+
+    thread = Thread.new do
+      connection._host_pool_current_database = 'some_other_database'
+
+      # Stop this thread and recede control to the main thread. It will
+      # wakeup this thread when it's time to move on.
+      Thread.stop
+
+      database_values.database_in_use_on_child_thread = connection._host_pool_current_database
+      database_values.database_config_on_child_thread = connection.instance_eval { @config[:database] }
+    end
+
+    # Wait for the thread to stop to control execution steps
+    next until thread.stop?
+
+    database_values.database_in_use_on_main_thread = connection._host_pool_current_database
+    database_values.database_config_in_use_on_main_thread = connection.instance_eval { @config[:database] }
+
+    thread.wakeup
+    thread.join
+  end
+end


### PR DESCRIPTION
# What does this PR do?

This PR makes ARHP database switching thread-safe by:

1. updating access to the the host pool database in a thread local manner.
2. always switch the database (and let mysql handle it being a no-op when it doesn't need to switch)
2. augment the connection adapter's internal `@config` to also work in a thread local manner

## Why is this helpful?

This allows ARHP to be used in Rails with concurrency turned on. Specifically for my use-case, this lets me set `config.allow_concurrency=true` in `config/environments/test.rb` for a feature/integration suite.  Without this change concurrency has to be disabled and this makes request processing extremely slow. 

## Trade-offs

### No longer caching the current database

Turning thread-safety on means that caching the current database no longer makes sense since the cached value may be stale based on other threads that have interacted with the database. Rather than querying the database to see what the current database is (which would work) the code now always issues the `select_db` call and lets MySQL handle responding to things. MySQL seems to treat operations that don't require switching the current database as no-ops and these are very fast.

### Always calling `clear_cache!`

 `clear_cache!` is always called now since the code no longer keeps track of the current database (and lets mysql manage that). This essentially kills any prepared statement caching that occurred, but this was already happening to a large degree when an application would switch databases.








