### PR TITLE
Add missing file to gem

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [1.0.3] - 2021-02-09
+### Fixed
+- Add missing file to the released gem. (https://github.com/zendesk/active_record_host_pool/pull/68)
+
 ## [1.0.2] - 2021-02-09
 ### Fixed
 - Fix unintended connection switching while clearing query cache in Rails 6.0. (https://github.com/zendesk/active_record_host_pool/pull/61)

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.files = [
     "Readme.md",
     "lib/active_record_host_pool.rb",
+    "lib/active_record_host_pool/clear_query_cache_patch.rb",
     "lib/active_record_host_pool/connection_adapter_mixin.rb",
     "lib/active_record_host_pool/connection_proxy.rb",
     "lib/active_record_host_pool/pool_proxy.rb",

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.2)
+    active_record_host_pool (1.0.3)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.2)
+    active_record_host_pool (1.0.3)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.2)
+    active_record_host_pool (1.0.3)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.2)
+    active_record_host_pool (1.0.3)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.0.2)
+    active_record_host_pool (1.0.3)
       activerecord (>= 4.2.0, < 6.1)
       mysql2
 

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
A new file was added to the repository in #61, but it wasn't reflected in the gemspec – so the released v1.0.2 doesn't work.

This PR fixes the gemspec and bumps the version to 1.0.3.