### PR TITLE
Remove unnecessary SELECT 1 when creating new ConnectionProxy

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Do not execute SELECT 1 query after creating a ConnectionProxy, rails already takes care of this (https://github.com/zendesk/active_record_host_pool/pull/69)
 
 ## [1.0.3] - 2021-02-09
 ### Fixed

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -144,11 +144,7 @@ module ActiveRecordHostPool
       @connection_proxy_cache ||= {}
       key = [connection, database]
 
-      @connection_proxy_cache[key] ||= begin
-        cx = ActiveRecordHostPool::ConnectionProxy.new(connection, database)
-        cx.execute('select 1')
-        cx
-      end
+      @connection_proxy_cache[key] ||= ActiveRecordHostPool::ConnectionProxy.new(connection, database)
     end
 
     def _clear_connection_proxy_cache


### PR DESCRIPTION
@zendesk/bolt @zendesk/database-gem-owners 

When Rails checks out a database connection from the connection pool, it [checks that the connection is alive](https://github.com/rails/rails/blob/v4.2.11.3/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L351). (The link is for rails 4.2, but the behavior appears unchanged up to rails 6.1.)

Executing an additional `SELECT 1` query should therefore be unnecessary.