### PR TITLE
Refactor tests

### DIFF
--- a/test/database.yml
+++ b/test/database.yml
@@ -35,7 +35,6 @@ test_pool_1_db_b:
   host: <%= mysql.host %>
   reconnect: true
 
-
 test_pool_1_db_not_there:
   adapter: mysql2
   encoding: utf8

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,76 +1,87 @@
 <% mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306') %>
-test_host_1_db_1:
+# ARHP creates separate connection pools based on the pool key
+# The pool key is defined:
+# host / port / socket / username / replica
+# therefore two databases with the same host, port, socket, username, and replica status will share a connection pool
+# two databases with the same host, port, etc but different usernames will _not_ share a connection pool
+# Below pool_1 has a host & username but pool_2 has a host, port, and username
+
+test_pool_1_db_a:
   adapter: mysql2
   encoding: utf8
-  database: arhp_test_1
+  database: arhp_test_db_a
   username: <%= mysql.user %>
   password: <%= mysql.password %>
   host: <%= mysql.host %>
   reconnect: true
 
 # Mimic configurations as read by active_record_shards/ar_flexmaster
-test_host_1_db_1_slave:
+test_pool_1_db_a_replica:
   adapter: mysql2
   encoding: utf8
-  database: arhp_test_1_slave
+  database: arhp_test_db_a_replica
   username: <%= mysql.user %>
   password: <%= mysql.password %>
   host: <%= mysql.host %>
   reconnect: true
   slave: true
 
-test_host_1_db_2:
+test_pool_1_db_b:
   adapter: mysql2
   encoding: utf8
-  database: arhp_test_2
+  database: arhp_test_db_b
   username: <%= mysql.user %>
   password: <%= mysql.password %>
   host: <%= mysql.host %>
   reconnect: true
 
-test_host_2_db_3:
+
+test_pool_1_db_not_there:
   adapter: mysql2
   encoding: utf8
-  database: arhp_test_3
+  database: arhp_test_db_not_there
+  username: <%= mysql.user %>
+  password: <%= mysql.password %>
+  host: <%= mysql.host %>
+  reconnect: true
+
+test_pool_2_db_d:
+  adapter: mysql2
+  encoding: utf8
+  database: arhp_test_db_d
   username: <%= mysql.user %>
   password: <%= mysql.password %>
   host: <%= mysql.host %>
   port: <%= mysql.port %>
   reconnect: true
 
-test_host_2_db_4:
+test_pool_2_db_e:
   adapter: mysql2
   encoding: utf8
-  database: arhp_test_4
+  database: arhp_test_db_e
   username: <%= mysql.user %>
   password: <%= mysql.password %>
   host: <%= mysql.host %>
   port: <%= mysql.port %>
   reconnect: true
 
-test_host_2_db_5:
+test_pool_3_db_e:
   adapter: mysql2
   encoding: utf8
-  database: arhp_test_4
+  database: arhp_test_db_e
   username: john-doe
   password:
   host: <%= mysql.host %>
   port: <%= mysql.port %>
   reconnect: true
 
-test_host_1_db_not_there:
+# test_pool_1_db_c needs to be the last database defined in the file
+# otherwise the test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
+# test fails
+test_pool_1_db_c:
   adapter: mysql2
   encoding: utf8
-  database: arhp_test_no_create
-  username: <%= mysql.user %>
-  password: <%= mysql.password %>
-  host: <%= mysql.host %>
-  reconnect: true
-
-test_host_1_db_shard:
-  adapter: mysql2
-  encoding: utf8
-  database: arhp_test_1_shard
+  database: arhp_test_db_c
   username: <%= mysql.user %>
   password: <%= mysql.password %>
   host: <%= mysql.host %>

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,10 +1,10 @@
 <% mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306') %>
-# ARHP creates separate connection pools based on the pool key
-# The pool key is defined:
-# host / port / socket / username / replica
-# therefore two databases with the same host, port, socket, username, and replica status will share a connection pool
-# two databases with the same host, port, etc but different usernames will _not_ share a connection pool
-# Below pool_1 has a host & username but pool_2 has a host, port, and username
+# ARHP creates separate connection pools based on the pool key.
+# The pool key is defined as:
+#   host / port / socket / username / replica
+# Therefore two databases with identical host, port, socket, username, and replica status will share a connection pool.
+# If any part (host, port, etc.) of the pool key differ, two databases will _not_ share a connection pool.
+# Below, "test_pool_1..." and "test_pool_2..." have identical host and username, but the port information differ.
 
 test_pool_1_db_a:
   adapter: mysql2

--- a/test/database.yml
+++ b/test/database.yml
@@ -2,9 +2,30 @@
 # ARHP creates separate connection pools based on the pool key.
 # The pool key is defined as:
 #   host / port / socket / username / replica
+#
 # Therefore two databases with identical host, port, socket, username, and replica status will share a connection pool.
 # If any part (host, port, etc.) of the pool key differ, two databases will _not_ share a connection pool.
-# Below, "test_pool_1..." and "test_pool_2..." have identical host and username, but the port information differ.
+#
+# Below, "test_pool_1..." and "test_pool_2..." have identical host, username, socket, and replica status but the port information differs.
+# Here the yml configurations are reformatted as a table to give a visual example:
+#
+# |----------+----------------+----------------|
+# |          |  test_pool_1   |  test_pool_2   |
+# |----------+----------------+----------------+
+# | host     | 127.0.0.1      | 127.0.0.1      |
+# | port     |                | 3306           |
+# | socket   |                |                |
+# | username | root           | root           |
+# | replica  | false          | false          |
+# |----------+----------------+----------------|
+#
+# Note: The configuration items must be explicitly defined or will be blank in the pool key.
+#       Configurations with matching _implicit_ items but differing _explicit_ items will create separate pools.
+#       e.g. "test_pool_1" will default to port 3306 but because it is not explicitly defined it will not share a pool with test_pool_2
+#
+#       ARHP will therefore create the following pool keys:
+#       test_pool_1 => 127.0.0.1///root/false
+#       test_pool_2 => 127.0.0.1/3306//root/false
 
 test_pool_1_db_a:
   adapter: mysql2

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -22,44 +22,44 @@ module ARHPTestSetup
   private
 
   def arhp_create_models
-    return if ARHPTestSetup.const_defined?('Test1')
+    return if ARHPTestSetup.const_defined?('Pool1DbA')
 
     eval <<-RUBY
-      # The placement of the Test1Shard class is important so that its
+      # The placement of the Pool1DbC class is important so that its
       # connection will not be the most recent connection established
-      # for test_host_1.
-      class Test1Shard < ::ActiveRecord::Base
-        establish_connection(:test_host_1_db_shard)
+      # for test_pool_1.
+      class Pool1DbC < ::ActiveRecord::Base
+        establish_connection(:test_pool_1_db_c)
       end
 
-      class Test1 < ActiveRecord::Base
+      class Pool1DbA < ActiveRecord::Base
         self.table_name = "tests"
-        establish_connection(:test_host_1_db_1)
+        establish_connection(:test_pool_1_db_a)
       end
 
-      class Test1Slave < ActiveRecord::Base
+      class Pool1DbAReplica < ActiveRecord::Base
         self.table_name = "tests"
-        establish_connection(:test_host_1_db_1_slave)
+        establish_connection(:test_pool_1_db_a_replica)
       end
 
-      class Test2 < ActiveRecord::Base
+      class Pool1DbB < ActiveRecord::Base
         self.table_name =  "tests"
-        establish_connection(:test_host_1_db_2)
+        establish_connection(:test_pool_1_db_b)
       end
 
-      class Test3 < ActiveRecord::Base
+      class Pool2DbD < ActiveRecord::Base
         self.table_name = "tests"
-        establish_connection(:test_host_2_db_3)
+        establish_connection(:test_pool_2_db_d)
       end
 
-      class Test4 < ActiveRecord::Base
+      class Pool2DbE < ActiveRecord::Base
         self.table_name = "tests"
-        establish_connection(:test_host_2_db_4)
+        establish_connection(:test_pool_2_db_e)
       end
 
-      class Test5 < ActiveRecord::Base
+      class Pool3DbE < ActiveRecord::Base
         self.table_name = "tests"
-        establish_connection(:test_host_2_db_5)
+        establish_connection(:test_pool_3_db_e)
       end
     RUBY
   end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -8,8 +8,8 @@ ActiveRecord::Schema.define(version: 1) do
 
   # Add a table only the shard database will have. Conditional
   # exists since Phenix loads the schema file for every database.
-  if ActiveRecord::Base.connection.current_database == 'arhp_test_1_shard'
-    create_table 'test1_shards' do |t|
+  if ActiveRecord::Base.connection.current_database == 'arhp_test_db_c'
+    create_table 'pool1_db_cs' do |t|
       t.string 'name'
     end
   end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -39,7 +39,7 @@ class ActiveRecordHostPoolTest < Minitest::Test
     refute_equal(Pool1DbA.connection.raw_connection, Pool2DbD.connection.raw_connection)
   end
 
-  def test_models_without_matching_usernames_should_not_share_a_connection
+  def test_models_with_different_usernames_should_not_share_a_connection
     refute_equal(Pool2DbE.connection.raw_connection, Pool3DbE.connection.raw_connection)
   end
 

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -43,7 +43,7 @@ class ActiveRecordHostPoolTest < Minitest::Test
     refute_equal(Pool2DbE.connection.raw_connection, Pool3DbE.connection.raw_connection)
   end
 
-  def test_models_without_match_replica_status_should_not_share_a_connection
+  def test_models_with_different_replica_status_should_not_share_a_connection
     refute_equal(Pool1DbA.connection.raw_connection, Pool1DbAReplica.connection.raw_connection)
   end
 

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -35,7 +35,7 @@ class ActiveRecordHostPoolTest < Minitest::Test
     assert_equal(Pool2DbD.connection.raw_connection, Pool2DbE.connection.raw_connection)
   end
 
-  def test_models_without_matching_ports_should_not_share_a_connection
+  def test_models_with_different_ports_should_not_share_a_connection
     refute_equal(Pool1DbA.connection.raw_connection, Pool2DbD.connection.raw_connection)
   end
 

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -18,26 +18,26 @@ class ActiveRecordHostPoolWrongDBTest < Minitest::Test
     begin
       eval <<-RUBY
         class TestNotThere < ActiveRecord::Base
-          establish_connection(:test_host_1_db_not_there)
+          establish_connection(:test_pool_1_db_not_there)
           connection
         end
       RUBY
     rescue Exception => e
-      assert e.message =~ /Unknown database 'arhp_test_no_create'/
+      assert e.message =~ /Unknown database 'arhp_test_db_not_there'/
       reached_first_exception = true
     end
 
     assert reached_first_exception
 
-    TestNotThere.establish_connection(:test_host_1_db_1)
+    TestNotThere.establish_connection(:test_pool_1_db_a)
 
     begin
       TestNotThere.connection
     rescue Exception => e
       # If the pool is caching a bad connection, that connection will be used instead
       # of the intended connection.
-      refute_includes e.message, "Unknown database 'arhp_test_no_create'"
-      assert_includes e.message, "Unknown database 'arhp_test_1'"
+      refute_includes e.message, "Unknown database 'arhp_test_db_not_there'"
+      assert_includes e.message, "Unknown database 'arhp_test_db_a'"
       reached_second_exception = true
     end
 


### PR DESCRIPTION
We've rewritten the tests to make it clearer what, exactly, they're testing and why they work the way that they do.

We renamed the database configuration keys from `test_host_1_db_1` to `test_pool_1_db_a`. Renaming `host` to `pool` feels better because each database configuration has the exact same host (`host: <%= mysql.host %>`)

We changed model names from things like `Test1` to `Pool1DbA` to make it clear that the model shares a connection pool with other models that start with `Pool1` and that it uses database  `A`.

This should help us work on making this gem `Rails 6.1` compatible because failing tests will be easier to diagnose without having to refer back to the model declarations to know which pool and database they refer to.


Co-authored-by: Cristina Matonte  <cristina.matonte@zendesk.com>