### PR TITLE
Use a maintained Ruby version for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Install Ruby, Bundler and gems
         uses: zendesk/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
           bundler-cache: true
       - run: bundle exec rake rubocop
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - .git/**/*
     - gemfiles/vendor/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
 Metrics:
   Enabled: false
 


### PR DESCRIPTION
Currently supporting until Ruby 2.7, so using that version for linting.

Older Ruby versions are already EOL


Depends on: https://github.com/zendesk/active_record_host_pool/pull/75