### PR TITLE
Add Ruby 2.7 in the tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           - 2.4
           - 2.5
           - 2.6
+          - 2.7
         gemfile:
           - rails4.2
           - rails5.1
@@ -43,6 +44,8 @@ jobs:
         exclude:
           - ruby-version: 2.4
             gemfile: rails6.0
+          - ruby-version: 2.7
+            gemfile: rails4.2
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:


### PR DESCRIPTION
Add 2.7 in the list of ruby-versions used for the tests. 2.7 is also the oldest maintained version

Excluding the combination AR 4.2 and Ruby 2.7 due to failures because of `BigDecimal undefined method new`, don't think it's worth fixing.

Depends on: https://github.com/zendesk/active_record_host_pool/pull/75