### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bquorning
+* @zendesk/database-gem-owners


### PR DESCRIPTION
Set it to be a group who's responsible for Zendesk owned database gems rather than a single individual.