### PR TITLE
Remove old Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - 2.4
-          - 2.5
           - 2.6
           - 2.7
         gemfile:
           - rails5.1
           - rails5.2
           - rails6.0
-        exclude:
-          - ruby-version: 2.4
-            gemfile: rails6.0
-          - ruby-version: 2.7
-            gemfile: rails4.2
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - .git/**/*
     - gemfiles/vendor/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.6
 Metrics:
   Enabled: false
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,7 +8,8 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ### Removed
 
-- Removed compatibility with Rails 4.2.
+- Removed compatibility with Rails 4.2. (https://github.com/zendesk/active_record_host_pool/pull/71)
+- Removed compatibility with Ruby 2.5 and lower. (https://github.com/zendesk/active_record_host_pool/pull/80)
 
 ## [1.0.3] - 2021-02-09
 ### Fixed

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |s|
   s.test_files = ["test/database.yml", "test/helper.rb", "test/schema.rb", "test/test_arhp.rb"]
   s.license = "MIT"
 
+  s.required_ruby_version = ">= 2.6.0"
+
   s.add_runtime_dependency("activerecord", ">= 5.1.0", "< 6.1")
   s.add_runtime_dependency("mysql2")
 


### PR DESCRIPTION
Remove Ruby 2.4 and 2.5 which stopped being supported a long time ago.

RuboCop target changed to match the minimum supported, else RuboCop
complains.

The commit is taken from #78, but I didn’t want to force push such changes to @anitsirc’s branch.