### PR TITLE
Add support for Rails 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    name: rake test Gemfile ${{ matrix.gemfile }} and Ruby ${{ matrix.ruby-version }}
+    name: rake test Gemfile ${{ matrix.gemfile }} and Ruby ${{ matrix.ruby-version }} (LCH ${{ matrix.legacy_connection_handling }})
     services:
       mysql:
         image: mysql:5.7
@@ -38,8 +38,19 @@ jobs:
           - rails5.1
           - rails5.2
           - rails6.0
+          - rails6.1
+        legacy_connection_handling:
+          - "false"
+        include:
+          - ruby-version: "2.6"
+            gemfile: rails6.1
+            legacy_connection_handling: "true"
+          - ruby-version: "2.7"
+            gemfile: rails6.1
+            legacy_connection_handling: "true"
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      LEGACY_CONNECTION_HANDLING: "${{ matrix.legacy_connection_handling }}"
     steps:
       - uses: zendesk/checkout@v2
       - name: Install Ruby, Bundler and gems
@@ -49,5 +60,4 @@ jobs:
           bundler-cache: true
       - name: Create user 'john-doe' in MySQL
         run: mysql --host 127.0.0.1 --port 3306 -uroot -e "CREATE USER 'john-doe'; GRANT SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX ON *.* TO 'john-doe'; FLUSH PRIVILEGES;"
-      - name: rake test Gemfile ${{ matrix.gemfile }} and Ruby ${{ matrix.ruby-version }}
-        run: bundle exec rake test
+      - run: bundle exec rake test

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Rails 6.1 (https://github.com/zendesk/active_record_host_pool/pull/82)
 
 ### Removed
-
 - Removed compatibility with Rails 4.2. (https://github.com/zendesk/active_record_host_pool/pull/71)
 - Removed compatibility with Ruby 2.5 and lower. (https://github.com/zendesk/active_record_host_pool/pull/80)
 

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -26,13 +26,13 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.6.0"
 
-  s.add_runtime_dependency("activerecord", ">= 5.1.0", "< 6.1")
+  s.add_runtime_dependency("activerecord", ">= 5.1.0", "< 7.0")
   s.add_runtime_dependency("mysql2")
 
   s.add_development_dependency("bump")
   s.add_development_dependency("minitest", ">= 5.10.0")
   s.add_development_dependency("mocha", ">= 1.4.0")
-  s.add_development_dependency("phenix")
+  s.add_development_dependency("phenix", ">= 1.0.1")
   s.add_development_dependency("rake", '>= 12.0.0')
   s.add_development_dependency('rubocop', '~> 0.80.0')
   s.add_development_dependency("shoulda")

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     active_record_host_pool (1.0.3)
-      activerecord (>= 5.1.0, < 6.1)
+      activerecord (>= 5.1.0, < 7.0)
       mysql2
 
 GEM
@@ -20,26 +20,26 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (8.0.0)
-    ast (2.4.0)
-    bump (0.9.0)
-    byebug (11.1.1)
-    concurrent-ruby (1.1.6)
-    i18n (1.8.2)
+    ast (2.4.2)
+    bump (0.10.0)
+    byebug (11.1.3)
+    concurrent-ruby (1.1.10)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    minitest (5.14.0)
-    mocha (1.11.2)
-    mysql2 (0.5.3)
-    parallel (1.19.1)
-    parser (2.7.0.2)
-      ast (~> 2.4.0)
-    phenix (0.6.0)
-      activerecord (>= 4.2, < 6.1)
+    minitest (5.16.3)
+    mocha (1.14.0)
+    mysql2 (0.5.4)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
+    phenix (1.0.1)
+      activerecord (>= 4.2, < 7.1)
       bundler
-    rainbow (3.0.0)
-    rake (13.0.1)
-    rexml (3.2.4)
-    rubocop (0.80.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -47,19 +47,20 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
-    shoulda (3.6.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (~> 3.0)
-    shoulda-context (1.2.2)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
+    ruby-progressbar (1.11.0)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.6)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
 
 DEPENDENCIES
@@ -70,10 +71,10 @@ DEPENDENCIES
   minitest (>= 5.10.0)
   mocha (>= 1.4.0)
   mysql2 (>= 0.3.18, < 0.6.0)
-  phenix
+  phenix (>= 1.0.1)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
   shoulda
 
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -2,43 +2,43 @@ PATH
   remote: ..
   specs:
     active_record_host_pool (1.0.3)
-      activerecord (>= 5.1.0, < 6.1)
+      activerecord (>= 5.1.0, < 7.0)
       mysql2
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.2.1)
-      activesupport (= 6.0.2.1)
-    activerecord (6.0.2.1)
-      activemodel (= 6.0.2.1)
-      activesupport (= 6.0.2.1)
-    activesupport (6.0.2.1)
+    activemodel (6.0.5.1)
+      activesupport (= 6.0.5.1)
+    activerecord (6.0.5.1)
+      activemodel (= 6.0.5.1)
+      activesupport (= 6.0.5.1)
+    activesupport (6.0.5.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
-    ast (2.4.0)
-    bump (0.9.0)
-    byebug (11.1.1)
-    concurrent-ruby (1.1.6)
-    i18n (1.8.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
+    ast (2.4.2)
+    bump (0.10.0)
+    byebug (11.1.3)
+    concurrent-ruby (1.1.10)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    minitest (5.14.0)
-    mocha (1.11.2)
-    mysql2 (0.5.3)
-    parallel (1.19.1)
-    parser (2.7.0.2)
-      ast (~> 2.4.0)
-    phenix (0.6.0)
-      activerecord (>= 4.2, < 6.1)
+    minitest (5.16.3)
+    mocha (1.14.0)
+    mysql2 (0.5.4)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
+    phenix (1.0.1)
+      activerecord (>= 4.2, < 7.1)
       bundler
-    rainbow (3.0.0)
-    rake (13.0.1)
-    rexml (3.2.4)
-    rubocop (0.80.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    rexml (3.2.5)
+    rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -46,20 +46,21 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    ruby-progressbar (1.10.1)
-    shoulda (3.6.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (~> 3.0)
-    shoulda-context (1.2.2)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
+    ruby-progressbar (1.11.0)
+    shoulda (4.0.0)
+      shoulda-context (~> 2.0)
+      shoulda-matchers (~> 4.0)
+    shoulda-context (2.0.0)
+    shoulda-matchers (4.5.1)
+      activesupport (>= 4.2.0)
     thread_safe (0.3.6)
-    tzinfo (1.2.6)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
-    zeitwerk (2.2.2)
+    zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-21
   ruby
 
 DEPENDENCIES
@@ -70,10 +71,10 @@ DEPENDENCIES
   minitest (>= 5.10.0)
   mocha (>= 1.4.0)
   mysql2 (>= 0.4.4)
-  phenix
+  phenix (>= 1.0.1)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
   shoulda
 
 BUNDLED WITH
-   2.1.4
+   2.3.7

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 6.1.0'
+gem 'mysql2', '~> 0.5'
+
+eval_gemfile 'common.rb'

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -8,18 +8,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.8.1)
-      activesupport (= 5.2.8.1)
-    activerecord (5.2.8.1)
-      activemodel (= 5.2.8.1)
-      activesupport (= 5.2.8.1)
-      arel (>= 9.0)
-    activesupport (5.2.8.1)
+    activemodel (6.1.6.1)
+      activesupport (= 6.1.6.1)
+    activerecord (6.1.6.1)
+      activemodel (= 6.1.6.1)
+      activesupport (= 6.1.6.1)
+    activesupport (6.1.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-    arel (9.0.0)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ast (2.4.2)
     bump (0.10.0)
     byebug (11.1.3)
@@ -54,10 +53,10 @@ GEM
     shoulda-context (2.0.0)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    thread_safe (0.3.6)
-    tzinfo (1.2.10)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   arm64-darwin-21
@@ -65,12 +64,12 @@ PLATFORMS
 
 DEPENDENCIES
   active_record_host_pool!
-  activerecord (~> 5.2.0)
+  activerecord (~> 6.1.0)
   bump
   byebug
   minitest (>= 5.10.0)
   mocha (>= 1.4.0)
-  mysql2 (>= 0.4.4, < 0.6.0)
+  mysql2 (~> 0.5)
   phenix (>= 1.0.1)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)

--- a/lib/active_record_host_pool/clear_query_cache_patch.rb
+++ b/lib/active_record_host_pool/clear_query_cache_patch.rb
@@ -26,6 +26,15 @@ if ActiveRecord.version >= Gem::Version.new('6.0')
         # restore in case clearing the cache changed the database
         connection.unproxied._host_pool_current_database = host_pool_current_database_was
       end
+
+      def clear_on_handler(handler)
+        handler.all_connection_pools.each do |pool|
+          db_was = pool.connection.unproxied._host_pool_current_database
+          pool.connection.clear_query_cache if pool.active_connection?
+        ensure
+          pool.connection.unproxied._host_pool_current_database = db_was
+        end
+      end
     end
   end
 

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -120,6 +120,8 @@ end
 
 ActiveRecord::ConnectionAdapters::Mysql2Adapter.include(ActiveRecordHostPool::DatabaseSwitch)
 
+# In Rails 6.1 Connection Pools are no longer instantiated in #establish_connection but in a
+# new pool method.
 if "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}" == '6.1'
   ActiveRecord::ConnectionAdapters::PoolConfig.prepend(ActiveRecordHostPool::PoolConfigPatch)
 end

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# rubocop:disable Lint/DuplicateMethods
+
 require 'delegate'
 require 'active_record'
 require 'active_record_host_pool/connection_adapter_mixin'
@@ -13,134 +15,280 @@ require 'active_record_host_pool/connection_adapter_mixin'
 # into a ConnectionProxy that can inform (on execute) which db we should be on.
 
 module ActiveRecordHostPool
-  class PoolProxy < Delegator
-    def initialize(spec)
-      super(spec)
-      @spec = spec
-      @config = spec.config
-    end
+  case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+  when '6.1'
 
-    def __getobj__
-      _connection_pool
-    end
-
-    def __setobj__(spec)
-      @spec = spec
-      @config = spec.config
-      @_pool_key = nil
-    end
-
-    def spec
-      @spec
-    end
-
-    def connection(*args)
-      real_connection = _connection_pool.connection(*args)
-      _connection_proxy_for(real_connection, @config[:database])
-    rescue Mysql2::Error, ActiveRecord::NoDatabaseError
-      _connection_pools.delete(_pool_key)
-      Kernel.raise
-    end
-
-    # by the time we are patched into ActiveRecord, the current thread has already established
-    # a connection.  thus we need to patch both connection and checkout/checkin
-    def checkout(*args, &block)
-      cx = _connection_pool.checkout(*args, &block)
-      _connection_proxy_for(cx, @config[:database])
-    end
-
-    def checkin(cx)
-      cx = cx.unproxied
-      _connection_pool.checkin(cx)
-    end
-
-    def with_connection
-      cx = checkout
-      yield cx
-    ensure
-      checkin cx
-    end
-
-    def disconnect!
-      p = _connection_pool(false)
-      return unless p
-
-      p.disconnect!
-      p.automatic_reconnect = true if p.respond_to?(:automatic_reconnect=)
-      _clear_connection_proxy_cache
-    end
-
-    def automatic_reconnect=(value)
-      p = _connection_pool(false)
-      return unless p
-
-      p.automatic_reconnect = value if p.respond_to?(:automatic_reconnect=)
-    end
-
-    def clear_reloadable_connections!
-      _connection_pool.clear_reloadable_connections!
-      _clear_connection_proxy_cache
-    end
-
-    def release_connection(*args)
-      p = _connection_pool(false)
-      return unless p
-
-      p.release_connection(*args)
-    end
-
-    def flush!
-      p = _connection_pool(false)
-      return unless p
-
-      p.flush!
-    end
-
-    def discard!
-      p = _connection_pool(false)
-      return unless p
-
-      p.discard!
-
-      # All connections in the pool (even if they're currently
-      # leased!) have just been discarded, along with the pool itself.
-      # Any further interaction with the pool (except #spec and #schema_cache)
-      # is undefined.
-      # Remove the connection for the given key so a new one can be created in its place
-      _connection_pools.delete(_pool_key)
-    end
-
-    private
-
-    def _connection_pools
-      @@_connection_pools ||= {}
-    end
-
-    def _pool_key
-      @_pool_key ||= "#{@config[:host]}/#{@config[:port]}/#{@config[:socket]}/#{@config[:username]}/#{@config[:slave] && 'slave'}"
-    end
-
-    def _connection_pool(auto_create = true)
-      pool = _connection_pools[_pool_key]
-      if pool.nil? && auto_create
-        pool = _connection_pools[_pool_key] = ActiveRecord::ConnectionAdapters::ConnectionPool.new(@spec)
+    class PoolProxy < Delegator
+      def initialize(pool_config)
+        super(pool_config)
+        @pool_config = pool_config
+        @config = pool_config.db_config.configuration_hash
       end
-      pool
-    end
 
-    def _connection_proxy_for(connection, database)
-      @connection_proxy_cache ||= {}
-      key = [connection, database]
+      def __getobj__
+        _connection_pool
+      end
 
-      @connection_proxy_cache[key] ||= begin
-        cx = ActiveRecordHostPool::ConnectionProxy.new(connection, database)
-        cx.execute('select 1')
-        cx
+      def __setobj__(pool_config)
+        @pool_config = pool_config
+        @config = pool_config.db_config.configuration_hash
+        @_pool_key = nil
+      end
+
+      def pool_config
+        @pool_config
+      end
+
+      def connection(*args)
+        real_connection = _connection_pool.connection(*args)
+        _connection_proxy_for(real_connection, @config[:database])
+      rescue Mysql2::Error, ActiveRecord::NoDatabaseError
+        _connection_pools.delete(_pool_key)
+        Kernel.raise
+      end
+
+      # by the time we are patched into ActiveRecord, the current thread has already established
+      # a connection.  thus we need to patch both connection and checkout/checkin
+      def checkout(*args, &block)
+        cx = _connection_pool.checkout(*args, &block)
+        _connection_proxy_for(cx, @config[:database])
+      end
+
+      def checkin(cx)
+        cx = cx.unproxied
+        _connection_pool.checkin(cx)
+      end
+
+      def with_connection
+        cx = checkout
+        yield cx
+      ensure
+        checkin cx
+      end
+
+      def disconnect!
+        p = _connection_pool(false)
+        return unless p
+
+        p.disconnect!
+        p.automatic_reconnect = true if p.respond_to?(:automatic_reconnect=)
+        _clear_connection_proxy_cache
+      end
+
+      def automatic_reconnect=(value)
+        p = _connection_pool(false)
+        return unless p
+
+        p.automatic_reconnect = value if p.respond_to?(:automatic_reconnect=)
+      end
+
+      def clear_reloadable_connections!
+        _connection_pool.clear_reloadable_connections!
+        _clear_connection_proxy_cache
+      end
+
+      def release_connection(*args)
+        p = _connection_pool(false)
+        return unless p
+
+        p.release_connection(*args)
+      end
+
+      def flush!
+        p = _connection_pool(false)
+        return unless p
+
+        p.flush!
+      end
+
+      def discard!
+        p = _connection_pool(false)
+        return unless p
+
+        p.discard!
+
+        # All connections in the pool (even if they're currently
+        # leased!) have just been discarded, along with the pool itself.
+        # Any further interaction with the pool (except #pool_config and #schema_cache)
+        # is undefined.
+        # Remove the connection for the given key so a new one can be created in its place
+        _connection_pools.delete(_pool_key)
+      end
+
+      private
+
+      def _connection_pools
+        @@_connection_pools ||= {}
+      end
+
+      def _pool_key
+        @_pool_key ||= "#{@config[:host]}/#{@config[:port]}/#{@config[:socket]}/" \
+                       "#{@config[:username]}/#{replica_configuration? && 'replica'}"
+      end
+
+      def _connection_pool(auto_create = true)
+        pool = _connection_pools[_pool_key]
+        if pool.nil? && auto_create
+          pool = _connection_pools[_pool_key] = ActiveRecord::ConnectionAdapters::ConnectionPool.new(@pool_config)
+        end
+        pool
+      end
+
+      def _connection_proxy_for(connection, database)
+        @connection_proxy_cache ||= {}
+        key = [connection, database]
+
+        @connection_proxy_cache[key] ||= begin
+          cx = ActiveRecordHostPool::ConnectionProxy.new(connection, database)
+          cx.execute('select 1')
+          cx
+        end
+      end
+
+      def _clear_connection_proxy_cache
+        @connection_proxy_cache = {}
+      end
+
+      def replica_configuration?
+        @config[:replica] || @config[:slave]
       end
     end
 
-    def _clear_connection_proxy_cache
-      @connection_proxy_cache = {}
+  else
+
+    class PoolProxy < Delegator
+      def initialize(spec)
+        super(spec)
+        @spec = spec
+        @config = spec.config
+      end
+
+      def __getobj__
+        _connection_pool
+      end
+
+      def __setobj__(spec)
+        @spec = spec
+        @config = spec.config
+        @_pool_key = nil
+      end
+
+      def spec
+        @spec
+      end
+
+      def connection(*args)
+        real_connection = _connection_pool.connection(*args)
+        _connection_proxy_for(real_connection, @config[:database])
+      rescue Mysql2::Error, ActiveRecord::NoDatabaseError
+        _connection_pools.delete(_pool_key)
+        Kernel.raise
+      end
+
+      # by the time we are patched into ActiveRecord, the current thread has already established
+      # a connection.  thus we need to patch both connection and checkout/checkin
+      def checkout(*args, &block)
+        cx = _connection_pool.checkout(*args, &block)
+        _connection_proxy_for(cx, @config[:database])
+      end
+
+      def checkin(cx)
+        cx = cx.unproxied
+        _connection_pool.checkin(cx)
+      end
+
+      def with_connection
+        cx = checkout
+        yield cx
+      ensure
+        checkin cx
+      end
+
+      def disconnect!
+        p = _connection_pool(false)
+        return unless p
+
+        p.disconnect!
+        p.automatic_reconnect = true if p.respond_to?(:automatic_reconnect=)
+        _clear_connection_proxy_cache
+      end
+
+      def automatic_reconnect=(value)
+        p = _connection_pool(false)
+        return unless p
+
+        p.automatic_reconnect = value if p.respond_to?(:automatic_reconnect=)
+      end
+
+      def clear_reloadable_connections!
+        _connection_pool.clear_reloadable_connections!
+        _clear_connection_proxy_cache
+      end
+
+      def release_connection(*args)
+        p = _connection_pool(false)
+        return unless p
+
+        p.release_connection(*args)
+      end
+
+      def flush!
+        p = _connection_pool(false)
+        return unless p
+
+        p.flush!
+      end
+
+      def discard!
+        p = _connection_pool(false)
+        return unless p
+
+        p.discard!
+
+        # All connections in the pool (even if they're currently
+        # leased!) have just been discarded, along with the pool itself.
+        # Any further interaction with the pool (except #spec and #schema_cache)
+        # is undefined.
+        # Remove the connection for the given key so a new one can be created in its place
+        _connection_pools.delete(_pool_key)
+      end
+
+      private
+
+      def _connection_pools
+        @@_connection_pools ||= {}
+      end
+
+      def _pool_key
+        @_pool_key ||= "#{@config[:host]}/#{@config[:port]}/#{@config[:socket]}/" \
+                       "#{@config[:username]}/#{@config[:slave] && 'slave'}"
+      end
+
+      def _connection_pool(auto_create = true)
+        pool = _connection_pools[_pool_key]
+        if pool.nil? && auto_create
+          pool = _connection_pools[_pool_key] = ActiveRecord::ConnectionAdapters::ConnectionPool.new(@spec)
+        end
+        pool
+      end
+
+      def _connection_proxy_for(connection, database)
+        @connection_proxy_cache ||= {}
+        key = [connection, database]
+
+        @connection_proxy_cache[key] ||= begin
+          cx = ActiveRecordHostPool::ConnectionProxy.new(connection, database)
+          cx.execute('select 1')
+          cx
+        end
+      end
+
+      def _clear_connection_proxy_cache
+        @connection_proxy_cache = {}
+      end
     end
+
   end
 end
+
+# rubocop:enable Lint/DuplicateMethods

--- a/test/database.yml
+++ b/test/database.yml
@@ -56,6 +56,15 @@ test_pool_1_db_b:
   host: <%= mysql.host %>
   reconnect: true
 
+test_pool_1_db_c:
+  adapter: mysql2
+  encoding: utf8
+  database: arhp_test_db_c
+  username: <%= mysql.user %>
+  password: <%= mysql.password %>
+  host: <%= mysql.host %>
+  reconnect: true
+
 test_pool_1_db_not_there:
   adapter: mysql2
   encoding: utf8
@@ -93,16 +102,4 @@ test_pool_3_db_e:
   password:
   host: <%= mysql.host %>
   port: <%= mysql.port %>
-  reconnect: true
-
-# test_pool_1_db_c needs to be the last database defined in the file
-# otherwise the test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
-# test fails
-test_pool_1_db_c:
-  adapter: mysql2
-  encoding: utf8
-  database: arhp_test_db_c
-  username: <%= mysql.user %>
-  password: <%= mysql.password %>
-  host: <%= mysql.host %>
   reconnect: true

--- a/test/database.yml
+++ b/test/database.yml
@@ -6,26 +6,26 @@
 # Therefore two databases with identical host, port, socket, username, and replica status will share a connection pool.
 # If any part (host, port, etc.) of the pool key differ, two databases will _not_ share a connection pool.
 #
-# Below, "test_pool_1..." and "test_pool_2..." have identical host, username, socket, and replica status but the port information differs.
-# Here the yml configurations are reformatted as a table to give a visual example:
+# `replica` in the pool key is a boolean indicating if the database is a replica/reader (true) or writer database (false).
 #
-# |----------+----------------+----------------|
+# Below, `test_pool_1...` and `test_pool_2...` have identical host, username, socket, and replica status but the port information differs.
+# Here the database configurations are formatted as a table to give a visual example:
+#
 # |          |  test_pool_1   |  test_pool_2   |
-# |----------+----------------+----------------+
+# |----------|----------------|----------------|
 # | host     | 127.0.0.1      | 127.0.0.1      |
 # | port     |                | 3306           |
 # | socket   |                |                |
 # | username | root           | root           |
 # | replica  | false          | false          |
-# |----------+----------------+----------------|
 #
-# Note: The configuration items must be explicitly defined or will be blank in the pool key.
-#       Configurations with matching _implicit_ items but differing _explicit_ items will create separate pools.
-#       e.g. "test_pool_1" will default to port 3306 but because it is not explicitly defined it will not share a pool with test_pool_2
+# The configuration items must be explicitly defined or they will be blank in the pool key.
+# Configurations with matching _implicit_ items but differing _explicit_ items will create separate pools.
+# e.g. `test_pool_1` will default to port 3306 but because it is not explicitly defined it will not share a pool with `test_pool_2`
 #
-#       ARHP will therefore create the following pool keys:
-#       test_pool_1 => 127.0.0.1///root/false
-#       test_pool_2 => 127.0.0.1/3306//root/false
+# ARHP will therefore create the following pool keys:
+#   test_pool_1 => 127.0.0.1///root/false
+#   test_pool_2 => 127.0.0.1/3306//root/false
 
 test_pool_1_db_a:
   adapter: mysql2

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,7 @@ require 'logger'
 require 'mocha/minitest'
 require 'phenix'
 
-RAILS_ENV = 'test'
+ENV['RAILS_ENV'] = 'test'
 ENV['LEGACY_CONNECTION_HANDLING'] = 'true' if ENV['LEGACY_CONNECTION_HANDLING'].nil?
 
 if ActiveRecord.version >= Gem::Version.new('6.1')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,6 +15,10 @@ if ActiveRecord.version >= Gem::Version.new('6.1')
   ActiveRecord::Base.legacy_connection_handling = (ENV['LEGACY_CONNECTION_HANDLING'] == 'true')
 end
 
+# rubocop:disable Layout/LineLength
+RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING = ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+# rubocop:enable Layout/LineLength
+
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + '/test.log')
 
 # BEGIN preventing_writes? patch
@@ -47,7 +51,7 @@ module ARHPTestSetup
   def arhp_create_models
     return if ARHPTestSetup.const_defined?('Pool1DbA')
 
-    if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+    if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
       eval <<-RUBY
         class AbstractPool1DbC < ActiveRecord::Base
           self.abstract_class = true
@@ -178,7 +182,7 @@ module ARHPTestSetup
   end
 
   def simulate_rails_app_active_record_railties
-    if ActiveRecord.version < Gem::Version.new('6.1') || ENV['LEGACY_CONNECTION_HANDLING'] == 'true'
+    unless RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
       # Necessary for testing ActiveRecord 6.0 which uses the connection
       # handlers when clearing query caches across all handlers when
       # an operation that dirties the cache is involved (e.g. create/insert,

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -175,4 +175,16 @@ module ARHPTestSetup
   ensure
     mod.define_method(method_name, method_body)
   end
+
+  def simulate_rails_app_active_record_railties
+    if ActiveRecord.version < Gem::Version.new('6.1') || ENV['LEGACY_CONNECTION_HANDLING'] == 'true'
+      # Necessary for testing ActiveRecord 6.0 which uses the connection
+      # handlers when clearing query caches across all handlers when
+      # an operation that dirties the cache is involved (e.g. create/insert,
+      # update, delete/destroy, truncate, etc.)
+      ActiveRecord::Base.connection_handlers = {
+        ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler
+      }
+    end
+  end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -78,20 +78,6 @@ module ARHPTestSetup
           self.table_name = "tests"
         end
 
-        class AbstractShardedModel < ActiveRecord::Base
-          self.abstract_class = true
-          connects_to shards: {
-                        default: { writing: :test_pool_1_db_shard_a },
-                        shard_b: { writing: :test_pool_1_db_shard_b, reading: :test_pool_1_db_shard_b_replica },
-                        shard_c: { writing: :test_pool_1_db_shard_c, reading: :test_pool_1_db_shard_c_replica },
-                        shard_d: { writing: :test_pool_2_db_shard_d, reading: :test_pool_2_db_shard_d_replica }
-                      }
-        end
-
-        class ShardedModel < AbstractShardedModel
-          self.table_name = "tests"
-        end
-
         class AbstractPool2DbD < ActiveRecord::Base
           self.abstract_class = true
           connects_to database: { writing: :test_pool_2_db_d }
@@ -116,6 +102,21 @@ module ARHPTestSetup
         end
 
         class Pool3DbE < AbstractPool3DbE
+          self.table_name = "tests"
+        end
+
+        # Test ARHP with Rails 6.1+ horizontal sharding functionality
+        class AbstractShardedModel < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to shards: {
+                        default: { writing: :test_pool_1_db_shard_a },
+                        shard_b: { writing: :test_pool_1_db_shard_b, reading: :test_pool_1_db_shard_b_replica },
+                        shard_c: { writing: :test_pool_1_db_shard_c, reading: :test_pool_1_db_shard_c_replica },
+                        shard_d: { writing: :test_pool_2_db_shard_d, reading: :test_pool_2_db_shard_d_replica }
+                      }
+        end
+
+        class ShardedModel < AbstractShardedModel
           self.table_name = "tests"
         end
       RUBY

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,7 @@ require 'mocha/minitest'
 require 'phenix'
 
 RAILS_ENV = 'test'
+ENV['LEGACY_CONNECTION_HANDLING'] = 'true' if ENV['LEGACY_CONNECTION_HANDLING'].nil?
 
 if ActiveRecord.version >= Gem::Version.new('6.1')
   ActiveRecord::Base.legacy_connection_handling = (ENV['LEGACY_CONNECTION_HANDLING'] == 'true')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -51,7 +51,7 @@ module ARHPTestSetup
   def arhp_create_models
     return if ARHPTestSetup.const_defined?('Pool1DbA')
 
-    if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
+    if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
       eval <<-RUBY
         class AbstractPool1DbC < ActiveRecord::Base
           self.abstract_class = true
@@ -182,7 +182,7 @@ module ARHPTestSetup
   end
 
   def simulate_rails_app_active_record_railties
-    unless RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
+    unless RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
       # Necessary for testing ActiveRecord 6.0 which uses the connection
       # handlers when clearing query caches across all handlers when
       # an operation that dirties the cache is involved (e.g. create/insert,

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,6 +10,10 @@ require 'phenix'
 
 RAILS_ENV = 'test'
 
+if ActiveRecord.version >= Gem::Version.new('6.1')
+  ActiveRecord::Base.legacy_connection_handling = (ENV['LEGACY_CONNECTION_HANDLING'] == 'true')
+end
+
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + '/test.log')
 
 Phenix.configure do |config|
@@ -22,44 +26,118 @@ module ARHPTestSetup
   def arhp_create_models
     return if ARHPTestSetup.const_defined?('Pool1DbA')
 
-    eval <<-RUBY
-      # The placement of the Pool1DbC class is important so that its
-      # connection will not be the most recent connection established
-      # for test_pool_1.
-      class Pool1DbC < ::ActiveRecord::Base
-        establish_connection(:test_pool_1_db_c)
-      end
+    if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+      eval <<-RUBY
+        class AbstractPool1DbC < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_1_db_c }
+        end
 
-      class Pool1DbA < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_1_db_a)
-      end
+        # The placement of the Pool1DbC class is important so that its
+        # connection will not be the most recent connection established
+        # for test_pool_1.
+        class Pool1DbC < AbstractPool1DbC
+        end
 
-      class Pool1DbAReplica < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_1_db_a_replica)
-      end
+        class AbstractPool1DbA < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_1_db_a, reading: :test_pool_1_db_a_replica }
+        end
 
-      class Pool1DbB < ActiveRecord::Base
-        self.table_name =  "tests"
-        establish_connection(:test_pool_1_db_b)
-      end
+        class Pool1DbA < AbstractPool1DbA
+          self.table_name = "tests"
+        end
 
-      class Pool2DbD < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_2_db_d)
-      end
+        class AbstractPool1DbB < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_1_db_b }
+        end
 
-      class Pool2DbE < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_2_db_e)
-      end
+        class Pool1DbB < AbstractPool1DbB
+          self.table_name = "tests"
+        end
 
-      class Pool3DbE < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_3_db_e)
-      end
-    RUBY
+        class AbstractShardedModel < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to shards: {
+                        default: { writing: :test_pool_1_db_shard_a },
+                        shard_b: { writing: :test_pool_1_db_shard_b, reading: :test_pool_1_db_shard_b_replica },
+                        shard_c: { writing: :test_pool_1_db_shard_c, reading: :test_pool_1_db_shard_c_replica },
+                        shard_d: { writing: :test_pool_2_db_shard_d, reading: :test_pool_2_db_shard_d_replica }
+                      }
+        end
+
+        class ShardedModel < AbstractShardedModel
+          self.table_name = "tests"
+        end
+
+        class AbstractPool2DbD < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_2_db_d }
+        end
+
+        class Pool2DbD < AbstractPool2DbD
+          self.table_name = "tests"
+        end
+
+        class AbstractPool2DbE < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_2_db_e }
+        end
+
+        class Pool2DbE < AbstractPool2DbE
+          self.table_name = "tests"
+        end
+
+        class AbstractPool3DbE < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_3_db_e }
+        end
+
+        class Pool3DbE < AbstractPool3DbE
+          self.table_name = "tests"
+        end
+      RUBY
+    else
+      eval <<-RUBY
+        # The placement of the Pool1DbC class is important so that its
+        # connection will not be the most recent connection established
+        # for test_pool_1.
+        class Pool1DbC < ActiveRecord::Base
+          establish_connection(:test_pool_1_db_c)
+        end
+
+        class Pool1DbA < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_1_db_a)
+        end
+
+        class Pool1DbAReplica < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_1_db_a_replica)
+        end
+
+        class Pool1DbB < ActiveRecord::Base
+          self.table_name =  "tests"
+          establish_connection(:test_pool_1_db_b)
+        end
+
+        class Pool2DbD < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_2_db_d)
+        end
+
+        class Pool2DbE < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_2_db_e)
+        end
+
+        class Pool3DbE < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_3_db_e)
+        end
+      RUBY
+    end
   end
 
   def current_database(klass)

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
 require_relative 'helper'
-ActiveRecord::Schema.define(version: 1) do
-  create_table 'tests', force: true do |t|
-    t.string   'val'
-  end
 
-  # Add a table only the shard database will have. Conditional
-  # exists since Phenix loads the schema file for every database.
-  if ActiveRecord::Base.connection.current_database == 'arhp_test_db_c'
-    create_table 'pool1_db_cs' do |t|
-      t.string 'name'
+begin
+  ActiveRecordHostPool.allowing_writes = true
+
+  ActiveRecord::Schema.define(version: 1) do
+    create_table 'tests', force: true do |t|
+      t.string   'val'
+    end
+
+    # Add a table only the shard database will have. Conditional
+    # exists since Phenix loads the schema file for every database.
+    if ActiveRecord::Base.connection.current_database == 'arhp_test_db_c'
+      create_table 'pool1_db_cs' do |t|
+        t.string 'name'
+      end
     end
   end
+ensure
+  ActiveRecordHostPool.allowing_writes = false
 end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -88,14 +88,6 @@ class ActiveRecordHostPoolTest < Minitest::Test
     assert_equal true, Pool1DbA.connection.send(:test_private_method)
   end
 
-  def test_should_not_share_a_query_cache
-    Pool1DbA.create(val: 'foo')
-    Pool1DbB.create(val: 'foobar')
-    Pool1DbA.connection.cache do
-      refute_equal Pool1DbA.first.val, Pool1DbB.first.val
-    end
-  end
-
   def test_object_creation
     Pool1DbA.create(val: 'foo')
     assert_equal('arhp_test_db_a', current_database(Pool1DbA))

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 class ActiveRecordHostPoolTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+    if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
       Phenix.rise! config_path: 'test/three_tier_database.yml'
     else
       Phenix.rise!

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -5,7 +5,11 @@ require_relative 'helper'
 class ActiveRecordHostPoolTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    Phenix.rise!
+    if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+      Phenix.rise! config_path: 'test/three_tier_database.yml'
+    else
+      Phenix.rise!
+    end
     arhp_create_models
   end
 
@@ -43,10 +47,6 @@ class ActiveRecordHostPoolTest < Minitest::Test
     refute_equal(Pool2DbE.connection.raw_connection, Pool3DbE.connection.raw_connection)
   end
 
-  def test_models_with_different_replica_status_should_not_share_a_connection
-    refute_equal(Pool1DbA.connection.raw_connection, Pool1DbAReplica.connection.raw_connection)
-  end
-
   def test_should_select_on_correct_database
     Pool1DbA.connection.send(:select_all, 'select 1')
     assert_equal 'arhp_test_db_a', current_database(Pool1DbA)
@@ -67,38 +67,6 @@ class ActiveRecordHostPoolTest < Minitest::Test
 
     Pool3DbE.connection.send(:insert, "insert into tests values(NULL, 'foo')")
     assert_equal 'arhp_test_db_e', current_database(Pool3DbE)
-  end
-
-  def test_models_with_matching_hosts_and_non_matching_databases_should_share_a_connection
-    simulate_rails_app_active_record_railties
-    assert_equal(Pool1DbA.connection.raw_connection, Pool1DbC.connection.raw_connection)
-  end
-
-  if ActiveRecord.version >= Gem::Version.new('6.0')
-    def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
-      simulate_rails_app_active_record_railties
-
-      # Remove patch that fixes an issue in Rails 6+ to ensure it still
-      # exists. If this begins to fail then it may mean that Rails has fixed
-      # the issue so that it no longer occurs.
-      without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
-        exception = assert_raises(ActiveRecord::StatementInvalid) do
-          ActiveRecord::Base.cache { Pool1DbC.create! }
-        end
-
-        assert_equal("Mysql2::Error: Table 'arhp_test_db_b.pool1_db_cs' doesn't exist", exception.message)
-      end
-    end
-
-    def test_models_with_matching_hosts_and_non_matching_databases_do_not_mix_up_underlying_database
-      simulate_rails_app_active_record_railties
-
-      # ActiveRecord 6.0 introduced a change that surfaced a problematic code
-      # path in active_record_host_pool when clearing caches across connection
-      # handlers which can cause the database to change.
-      # See ActiveRecordHostPool::ClearQueryCachePatch
-      ActiveRecord::Base.cache { Pool1DbC.create! }
-    end
   end
 
   def test_connection_returns_a_proxy
@@ -163,7 +131,7 @@ class ActiveRecordHostPoolTest < Minitest::Test
     conn.expects(:execute_without_switching)
     conn.expects(:_switch_connection).never
     assert conn._host_pool_current_database
-    conn.create_database(:some_args)
+    conn.create_database(:some_args, charset: 'utf8mb4')
   end
 
   def test_no_switch_when_dropping_db
@@ -214,19 +182,5 @@ class ActiveRecordHostPoolTest < Minitest::Test
     conn = pool.connection
     pool.expects(:checkin).with(conn)
     pool.release_connection
-  end
-
-  private
-
-  def simulate_rails_app_active_record_railties
-    if ActiveRecord.version >= Gem::Version.new('6.0')
-      # Necessary for testing ActiveRecord 6.0 which uses the connection
-      # handlers when clearing query caches across all handlers when
-      # an operation that dirties the cache is involved (e.g. create/insert,
-      # update, delete/destroy, truncate, etc.)
-      ActiveRecord::Base.connection_handlers = {
-        ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler
-      }
-    end
   end
 end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -14,6 +14,8 @@ class ActiveRecordHostPoolTest < Minitest::Test
   end
 
   def teardown
+    ActiveRecord::Base.connection.disconnect!
+    ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
     Phenix.burn!
   end
 

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 class ActiveRecordHostPoolTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
+    if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
       Phenix.rise! config_path: 'test/three_tier_database.yml'
     else
       Phenix.rise!

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 class ActiveRecordHostCachingTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+    if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
       Phenix.rise! config_path: 'test/three_tier_database.yml'
     else
       Phenix.rise!

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class ActiveRecordHostCachingTest < Minitest::Test
+  include ARHPTestSetup
+  def setup
+    if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+      Phenix.rise! config_path: 'test/three_tier_database.yml'
+    else
+      Phenix.rise!
+    end
+    arhp_create_models
+  end
+
+  def teardown
+    ActiveRecord::Base.connection.disconnect!
+    ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
+    Phenix.burn!
+  end
+
+  def test_should_not_share_a_query_cache
+    if ActiveRecord.version >= Gem::Version.new('6.0')
+      ActiveRecord::Base.clear_query_caches_for_current_thread
+    end
+
+    Pool1DbA.create(val: 'foo')
+    Pool1DbB.create(val: 'foobar')
+
+    Pool1DbA.connection.cache do
+      refute_equal Pool1DbA.first.val, Pool1DbB.first.val
+    end
+  end
+
+  if ActiveRecord.version >= Gem::Version.new('6.0')
+    def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
+      simulate_rails_app_active_record_railties
+
+      # Reset the connections post-setup so that we ensure the last DB isn't arhp_test_db_c
+      ActiveRecord::Base.connection.discard!
+      ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
+      ActiveRecord::Base.establish_connection(:test_pool_1_db_a)
+
+      # Ensure this works _with_ the patch
+      ActiveRecord::Base.cache { Pool1DbC.create! }
+
+      # Remove patch that fixes an issue in Rails 6+ to ensure it still
+      # exists. If this begins to fail then it may mean that Rails has fixed
+      # the issue so that it no longer occurs.
+      without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
+        without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_on_handler) do
+          exception = assert_raises(ActiveRecord::StatementInvalid) do
+            ActiveRecord::Base.cache { Pool1DbC.create! }
+          end
+
+          cached_db = Pool1DbC.connection.unproxied.pool.connections.first.instance_variable_get(:@_cached_current_database)
+          assert_equal("Mysql2::Error: Table '#{cached_db}.pool1_db_cs' doesn't exist", exception.message)
+        end
+      end
+    end
+
+    def test_models_with_matching_hosts_and_non_matching_databases_do_not_mix_up_underlying_database
+      simulate_rails_app_active_record_railties
+      # ActiveRecord will clear the query cache after any action that dirties the cache (create, update, etc)
+      # Because we're testing the patch we want to ensure it runs at least once
+      ActiveRecord::Base.clear_query_caches_for_current_thread
+
+      # ActiveRecord 6.0 introduced a change that surfaced a problematic code
+      # path in active_record_host_pool when clearing caches across connection
+      # handlers which can cause the database to change.
+      # See ActiveRecordHostPool::ClearQueryCachePatch
+      ActiveRecord::Base.cache { Pool1DbC.create! }
+    end
+  end
+end

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 class ActiveRecordHostCachingTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
+    if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
       Phenix.rise! config_path: 'test/three_tier_database.yml'
     else
       Phenix.rise!

--- a/test/test_arhp_legacy_connection_handling_only_tests.rb
+++ b/test/test_arhp_legacy_connection_handling_only_tests.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+unless ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+  class ActiveRecordHostPoolLegacyConnectiongHandlingTest < Minitest::Test
+    include ARHPTestSetup
+    def setup
+      Phenix.rise!
+      arhp_create_models
+    end
+
+    def teardown
+      Phenix.burn!
+    end
+
+    def test_models_without_matching_replica_status_should_not_share_a_connection
+      refute_equal(Pool1DbA.connection.raw_connection, Pool1DbAReplica.connection.raw_connection)
+    end
+
+    def test_models_with_matching_hosts_and_non_matching_databases_should_share_a_connection
+      simulate_rails_app_active_record_railties
+      assert_equal(Pool1DbA.connection.raw_connection, Pool1DbC.connection.raw_connection)
+    end
+
+    if ActiveRecord.version >= Gem::Version.new('6.0')
+      def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
+        simulate_rails_app_active_record_railties
+
+        # Remove patch that fixes an issue in Rails 6+ to ensure it still
+        # exists. If this begins to fail then it may mean that Rails has fixed
+        # the issue so that it no longer occurs.
+        without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
+          without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_on_handler) do
+            exception = assert_raises(ActiveRecord::StatementInvalid) do
+              ActiveRecord::Base.establish_connection(:test_pool_1_db_a)
+              ActiveRecord::Base.cache { Pool1DbC.create! }
+            end
+
+            cached_db = ActiveRecord::Base.connection.unproxied.instance_variable_get(:@_cached_current_database)
+            assert_equal("Mysql2::Error: Table '#{cached_db}.pool1_db_cs' doesn't exist", exception.message)
+          end
+        end
+      end
+
+      def test_models_with_matching_hosts_and_non_matching_databases_do_not_mix_up_underlying_database
+        simulate_rails_app_active_record_railties
+
+        # ActiveRecord 6.0 introduced a change that surfaced a problematic code
+        # path in active_record_host_pool when clearing caches across connection
+        # handlers which can cause the database to change.
+        # See ActiveRecordHostPool::ClearQueryCachePatch
+        ActiveRecord::Base.cache { Pool1DbC.create! }
+      end
+    end
+
+    private
+
+    def simulate_rails_app_active_record_railties
+      if ActiveRecord.version >= Gem::Version.new('6.0')
+        # Necessary for testing ActiveRecord 6.0 which uses the connection
+        # handlers when clearing query caches across all handlers when
+        # an operation that dirties the cache is involved (e.g. create/insert,
+        # update, delete/destroy, truncate, etc.)
+        ActiveRecord::Base.connection_handlers = {
+          ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler
+        }
+      end
+    end
+  end
+end

--- a/test/test_arhp_legacy_connection_handling_only_tests.rb
+++ b/test/test_arhp_legacy_connection_handling_only_tests.rb
@@ -19,53 +19,8 @@ unless ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.le
     end
 
     def test_models_with_matching_hosts_and_non_matching_databases_should_share_a_connection
-      simulate_rails_app_active_record_railties
+      simulate_rails_app_active_record_railties if ActiveRecord.version >= Gem::Version.new('6.1')
       assert_equal(Pool1DbA.connection.raw_connection, Pool1DbC.connection.raw_connection)
-    end
-
-    if ActiveRecord.version >= Gem::Version.new('6.0')
-      def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
-        simulate_rails_app_active_record_railties
-
-        # Remove patch that fixes an issue in Rails 6+ to ensure it still
-        # exists. If this begins to fail then it may mean that Rails has fixed
-        # the issue so that it no longer occurs.
-        without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
-          without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_on_handler) do
-            exception = assert_raises(ActiveRecord::StatementInvalid) do
-              ActiveRecord::Base.establish_connection(:test_pool_1_db_a)
-              ActiveRecord::Base.cache { Pool1DbC.create! }
-            end
-
-            cached_db = ActiveRecord::Base.connection.unproxied.instance_variable_get(:@_cached_current_database)
-            assert_equal("Mysql2::Error: Table '#{cached_db}.pool1_db_cs' doesn't exist", exception.message)
-          end
-        end
-      end
-
-      def test_models_with_matching_hosts_and_non_matching_databases_do_not_mix_up_underlying_database
-        simulate_rails_app_active_record_railties
-
-        # ActiveRecord 6.0 introduced a change that surfaced a problematic code
-        # path in active_record_host_pool when clearing caches across connection
-        # handlers which can cause the database to change.
-        # See ActiveRecordHostPool::ClearQueryCachePatch
-        ActiveRecord::Base.cache { Pool1DbC.create! }
-      end
-    end
-
-    private
-
-    def simulate_rails_app_active_record_railties
-      if ActiveRecord.version >= Gem::Version.new('6.0')
-        # Necessary for testing ActiveRecord 6.0 which uses the connection
-        # handlers when clearing query caches across all handlers when
-        # an operation that dirties the cache is involved (e.g. create/insert,
-        # update, delete/destroy, truncate, etc.)
-        ActiveRecord::Base.connection_handlers = {
-          ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler
-        }
-      end
     end
   end
 end

--- a/test/test_arhp_legacy_connection_handling_only_tests.rb
+++ b/test/test_arhp_legacy_connection_handling_only_tests.rb
@@ -2,7 +2,7 @@
 
 require_relative 'helper'
 
-unless RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
+unless RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
   class ActiveRecordHostPoolLegacyConnectiongHandlingTest < Minitest::Test
     include ARHPTestSetup
     def setup

--- a/test/test_arhp_legacy_connection_handling_only_tests.rb
+++ b/test/test_arhp_legacy_connection_handling_only_tests.rb
@@ -11,6 +11,8 @@ unless ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.le
     end
 
     def teardown
+      ActiveRecord::Base.connection.disconnect!
+      ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
       Phenix.burn!
     end
 

--- a/test/test_arhp_legacy_connection_handling_only_tests.rb
+++ b/test/test_arhp_legacy_connection_handling_only_tests.rb
@@ -2,7 +2,7 @@
 
 require_relative 'helper'
 
-unless ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+unless RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
   class ActiveRecordHostPoolLegacyConnectiongHandlingTest < Minitest::Test
     include ARHPTestSetup
     def setup

--- a/test/test_arhp_legacy_connection_handling_only_tests.rb
+++ b/test/test_arhp_legacy_connection_handling_only_tests.rb
@@ -21,7 +21,9 @@ unless RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
     end
 
     def test_models_with_matching_hosts_and_non_matching_databases_should_share_a_connection
-      simulate_rails_app_active_record_railties if ActiveRecord.version >= Gem::Version.new('6.1')
+      # ActiveRecord 6.0+ has additional behavior when an operation dirties the cache
+      simulate_rails_app_active_record_railties if ActiveRecord.version >= Gem::Version.new('6.0')
+
       assert_equal(Pool1DbA.connection.raw_connection, Pool1DbC.connection.raw_connection)
     end
   end

--- a/test/test_arhp_with_new_connection_handling.rb
+++ b/test/test_arhp_with_new_connection_handling.rb
@@ -14,31 +14,6 @@ if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy
       Phenix.burn!
     end
 
-    def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
-      # Remove patch that fixes an issue in Rails 6+ to ensure it still
-      # exists. If this begins to fail then it may mean that Rails has fixed
-      # the issue so that it no longer occurs.
-      without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
-        without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_on_handler) do
-          exception = assert_raises(ActiveRecord::StatementInvalid) do
-            ActiveRecord::Base.establish_connection(:test_pool_1_db_a)
-            ActiveRecord::Base.cache { Pool1DbC.create! }
-          end
-
-          cached_db = ActiveRecord::Base.connection.unproxied.instance_variable_get(:@_cached_current_database)
-          assert_equal("Mysql2::Error: Table '#{cached_db}.pool1_db_cs' doesn't exist", exception.message)
-        end
-      end
-    end
-
-    def test_models_with_matching_hosts_and_non_matching_databases_do_not_mix_up_underlying_database
-      # ActiveRecord 6.0 introduced a change that surfaced a problematic code
-      # path in active_record_host_pool when clearing caches across connection
-      # handlers which can cause the database to change.
-      # See ActiveRecordHostPool::ClearQueryCachePatch
-      ActiveRecord::Base.cache { Pool1DbC.create! }
-    end
-
     def test_correctly_writes_to_sharded_databases
       AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
         ShardedModel.create!

--- a/test/test_arhp_with_new_connection_handling.rb
+++ b/test/test_arhp_with_new_connection_handling.rb
@@ -11,6 +11,8 @@ if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy
     end
 
     def teardown
+      ActiveRecord::Base.connection.disconnect!
+      ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
       Phenix.burn!
     end
 

--- a/test/test_arhp_with_new_connection_handling.rb
+++ b/test/test_arhp_with_new_connection_handling.rb
@@ -2,7 +2,7 @@
 
 require_relative 'helper'
 
-if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
   class ActiveRecordHostPoolTestWithNewConnectionHandling < Minitest::Test
     include ARHPTestSetup
     def setup

--- a/test/test_arhp_with_new_connection_handling.rb
+++ b/test/test_arhp_with_new_connection_handling.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+  class ActiveRecordHostPoolTestWithNewConnectionHandling < Minitest::Test
+    include ARHPTestSetup
+    def setup
+      Phenix.rise! config_path: 'test/three_tier_database.yml'
+      arhp_create_models
+    end
+
+    def teardown
+      Phenix.burn!
+    end
+
+    def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
+      # Remove patch that fixes an issue in Rails 6+ to ensure it still
+      # exists. If this begins to fail then it may mean that Rails has fixed
+      # the issue so that it no longer occurs.
+      without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
+        without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_on_handler) do
+          exception = assert_raises(ActiveRecord::StatementInvalid) do
+            ActiveRecord::Base.establish_connection(:test_pool_1_db_a)
+            ActiveRecord::Base.cache { Pool1DbC.create! }
+          end
+
+          cached_db = ActiveRecord::Base.connection.unproxied.instance_variable_get(:@_cached_current_database)
+          assert_equal("Mysql2::Error: Table '#{cached_db}.pool1_db_cs' doesn't exist", exception.message)
+        end
+      end
+    end
+
+    def test_models_with_matching_hosts_and_non_matching_databases_do_not_mix_up_underlying_database
+      # ActiveRecord 6.0 introduced a change that surfaced a problematic code
+      # path in active_record_host_pool when clearing caches across connection
+      # handlers which can cause the database to change.
+      # See ActiveRecordHostPool::ClearQueryCachePatch
+      ActiveRecord::Base.cache { Pool1DbC.create! }
+    end
+
+    def test_correctly_writes_to_sharded_databases
+      AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
+        ShardedModel.create!
+      end
+
+      AbstractShardedModel.connected_to(role: :writing, shard: :shard_d) do
+        ShardedModel.create!
+      end
+
+      records_on_shard_b = AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
+        ShardedModel.count
+      end
+      records_on_shard_d = AbstractShardedModel.connected_to(role: :writing, shard: :shard_d) do
+        ShardedModel.count
+      end
+
+      assert_equal 1, records_on_shard_b
+      assert_equal 1, records_on_shard_d
+      assert_equal 0, ShardedModel.count
+    end
+
+    def test_shards_with_matching_hosts_ports_sockets_usernames_and_replica_status_should_share_a_connection
+      default_shard_connection = ShardedModel.connection.raw_connection
+      pool_1_shard_b_writing_connection = AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
+        ShardedModel.connection.raw_connection
+      end
+      pool_1_shard_b_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_b) do
+        ShardedModel.connection.raw_connection
+      end
+      pool_1_shard_c_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_c) do
+        ShardedModel.connection.raw_connection
+      end
+
+      assert_equal(default_shard_connection, pool_1_shard_b_writing_connection)
+      assert_equal(pool_1_shard_b_reading_connection, pool_1_shard_c_reading_connection)
+    end
+
+    def test_shards_without_matching_ports_should_not_share_a_connection
+      default_shard_connection = ShardedModel.connection.raw_connection
+      pool_1_shard_b_writing_connection = AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
+        ShardedModel.connection.raw_connection
+      end
+      pool_2_shard_d_writing_connection = AbstractShardedModel.connected_to(role: :writing, shard: :shard_d) do
+        ShardedModel.connection.raw_connection
+      end
+
+      refute_equal(default_shard_connection, pool_2_shard_d_writing_connection)
+      refute_equal(pool_1_shard_b_writing_connection, pool_2_shard_d_writing_connection)
+    end
+
+    def test_reading_and_writing_roles_should_not_share_a_connection
+      refute_equal(
+        (AbstractPool1DbA.connected_to(role: :writing) { Pool1DbA.connection.raw_connection }),
+        (AbstractPool1DbA.connected_to(role: :reading) { Pool1DbA.connection.raw_connection })
+      )
+    end
+
+    def test_sharded_reading_and_writing_roles_should_not_share_a_connection
+      shard_c_writing_connection = AbstractShardedModel.connected_to(role: :writing, shard: :shard_c) do
+        ShardedModel.connection.raw_connection
+      end
+      shard_c_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_c) do
+        ShardedModel.connection.raw_connection
+      end
+
+      refute_equal(shard_c_writing_connection, shard_c_reading_connection)
+    end
+
+    def test_sharded_reading_roles_without_matching_ports_should_not_share_a_connection
+      shard_c_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_c) do
+        ShardedModel.connection.raw_connection
+      end
+      shard_d_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_d) do
+        ShardedModel.connection.raw_connection
+      end
+
+      refute_equal(shard_c_reading_connection, shard_d_reading_connection)
+    end
+  end
+end

--- a/test/test_arhp_with_non_legacy_connection_handling.rb
+++ b/test/test_arhp_with_non_legacy_connection_handling.rb
@@ -2,8 +2,8 @@
 
 require_relative 'helper'
 
-if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
-  class ActiveRecordHostPoolTestWithNewConnectionHandling < Minitest::Test
+if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
+  class ActiveRecordHostPoolTestWithNonlegacyConnectionHandling < Minitest::Test
     include ARHPTestSetup
     def setup
       Phenix.rise! config_path: 'test/three_tier_database.yml'

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 class ActiveRecordHostPoolWrongDBTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+    if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
       Phenix.load_database_config 'test/three_tier_database.yml'
     else
       Phenix.load_database_config

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -5,7 +5,7 @@ require_relative 'helper'
 class ActiveRecordHostPoolWrongDBTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    if RAILS_6_1_WITH_NEW_CONNECTION_HANDLING
+    if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
       Phenix.load_database_config 'test/three_tier_database.yml'
     else
       Phenix.load_database_config

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -5,7 +5,11 @@ require_relative 'helper'
 class ActiveRecordHostPoolWrongDBTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    Phenix.load_database_config
+    if ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+      Phenix.load_database_config 'test/three_tier_database.yml'
+    else
+      Phenix.load_database_config
+    end
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -13,6 +13,10 @@ class ActiveRecordHostPoolWrongDBTest < Minitest::Test
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 
+  def teardown
+    Phenix.burn!
+  end
+
   # rake db:create uses a pattern where it tries to connect to a non-existant database.
   # but then we had this left in the connection pool cache.
   def test_connecting_to_wrong_db_first

--- a/test/three_tier_database.yml
+++ b/test/three_tier_database.yml
@@ -1,4 +1,7 @@
 <% mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306') %>
+
+# This .yml file is loaded in Rails 6.1 when ActiveRecord::Base.legacy_connection_handling = false
+#
 # ARHP creates separate connection pools based on the pool key.
 # The pool key is defined as:
 #   host / port / socket / username / replica
@@ -6,26 +9,30 @@
 # Therefore two databases with identical host, port, socket, username, and replica status will share a connection pool.
 # If any part (host, port, etc.) of the pool key differ, two databases will _not_ share a connection pool.
 #
-# Below, "test_pool_1..." and "test_pool_2..." have identical host, username, socket, and replica status but the port information differs.
-# Here the yml configurations are reformatted as a table to give a visual example:
+# `replica` in the pool key is a boolean indicating if the database is a replica/reader (true) or writer database (false).
+# In Rails 6.1 models when you call:
+#  `connected_to(role: :writing)` it will access the writer/primary database
 #
-# |----------+----------------+----------------|
+#  `connected_to(role: :reading)` it will access the replica/reader database
+#
+# Below, `test_pool_1...` and `test_pool_2...` have identical host, username, socket, and replica status but the port information differs.
+# Here the database configurations are formatted as a table to give a visual example:
+#
 # |          |  test_pool_1   |  test_pool_2   |
-# |----------+----------------+----------------+
+# |----------|----------------|----------------|
 # | host     | 127.0.0.1      | 127.0.0.1      |
 # | port     |                | 3306           |
 # | socket   |                |                |
 # | username | root           | root           |
 # | replica  | false          | false          |
-# |----------+----------------+----------------|
 #
-# Note: The configuration items must be explicitly defined or will be blank in the pool key.
-#       Configurations with matching _implicit_ items but differing _explicit_ items will create separate pools.
-#       e.g. "test_pool_1" will default to port 3306 but because it is not explicitly defined it will not share a pool with test_pool_2
+# The configuration items must be explicitly defined or they will be blank in the pool key.
+# Configurations with matching _implicit_ items but differing _explicit_ items will create separate pools.
+# e.g. `test_pool_1` will default to port 3306 but because it is not explicitly defined it will not share a pool with `test_pool_2`
 #
-#       ARHP will therefore create the following pool keys:
-#       test_pool_1 => 127.0.0.1///root/false
-#       test_pool_2 => 127.0.0.1/3306//root/false
+# ARHP will therefore create the following pool keys:
+#   test_pool_1 => 127.0.0.1///root/false
+#   test_pool_2 => 127.0.0.1/3306//root/false
 
 test:
   test_pool_1_db_a:

--- a/test/three_tier_database.yml
+++ b/test/three_tier_database.yml
@@ -57,6 +57,15 @@ test:
     host: <%= mysql.host %>
     reconnect: true
 
+  test_pool_1_db_c:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_c
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
   test_pool_1_db_not_there:
     adapter: mysql2
     encoding: utf8
@@ -162,16 +171,4 @@ test:
     password:
     host: <%= mysql.host %>
     port: <%= mysql.port %>
-    reconnect: true
-
-  # test_pool_1_db_c needs to be the last database defined in the file
-  # otherwise the test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
-  # test fails
-  test_pool_1_db_c:
-    adapter: mysql2
-    encoding: utf8
-    database: arhp_test_db_c
-    username: <%= mysql.user %>
-    password: <%= mysql.password %>
-    host: <%= mysql.host %>
     reconnect: true

--- a/test/three_tier_database.yml
+++ b/test/three_tier_database.yml
@@ -125,7 +125,7 @@ test:
   test_pool_2_db_shard_d:
     adapter: mysql2
     encoding: utf8
-    database: arhp_test_db_shard_d_replica
+    database: arhp_test_db_shard_d
     username: <%= mysql.user %>
     password: <%= mysql.password %>
     host: <%= mysql.host %>
@@ -135,7 +135,7 @@ test:
   test_pool_2_db_shard_d_replica:
     adapter: mysql2
     encoding: utf8
-    database: arhp_test_db_shard_d
+    database: arhp_test_db_shard_d_replica
     username: <%= mysql.user %>
     password: <%= mysql.password %>
     host: <%= mysql.host %>

--- a/test/three_tier_database.yml
+++ b/test/three_tier_database.yml
@@ -1,0 +1,177 @@
+<% mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306') %>
+# ARHP creates separate connection pools based on the pool key.
+# The pool key is defined as:
+#   host / port / socket / username / replica
+#
+# Therefore two databases with identical host, port, socket, username, and replica status will share a connection pool.
+# If any part (host, port, etc.) of the pool key differ, two databases will _not_ share a connection pool.
+#
+# Below, "test_pool_1..." and "test_pool_2..." have identical host, username, socket, and replica status but the port information differs.
+# Here the yml configurations are reformatted as a table to give a visual example:
+#
+# |----------+----------------+----------------|
+# |          |  test_pool_1   |  test_pool_2   |
+# |----------+----------------+----------------+
+# | host     | 127.0.0.1      | 127.0.0.1      |
+# | port     |                | 3306           |
+# | socket   |                |                |
+# | username | root           | root           |
+# | replica  | false          | false          |
+# |----------+----------------+----------------|
+#
+# Note: The configuration items must be explicitly defined or will be blank in the pool key.
+#       Configurations with matching _implicit_ items but differing _explicit_ items will create separate pools.
+#       e.g. "test_pool_1" will default to port 3306 but because it is not explicitly defined it will not share a pool with test_pool_2
+#
+#       ARHP will therefore create the following pool keys:
+#       test_pool_1 => 127.0.0.1///root/false
+#       test_pool_2 => 127.0.0.1/3306//root/false
+
+test:
+  test_pool_1_db_a:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_a
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  # Mimic configurations as read by active_record_shards/ar_flexmaster
+  test_pool_1_db_a_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_a_replica
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+    replica: true
+
+  test_pool_1_db_b:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_b
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_not_there:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_not_there
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_shard_a:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_a
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_shard_b:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_b
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_shard_b_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_b_replica
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+    replica: true
+
+  test_pool_1_db_shard_c:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_c
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_shard_c_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_c_replica
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+    replica: true
+
+  test_pool_2_db_shard_d:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_d_replica
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+
+  test_pool_2_db_shard_d_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_d
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+    replica: true
+
+  test_pool_2_db_d:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_d
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+
+  test_pool_2_db_e:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_e
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+
+  test_pool_3_db_e:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_e
+    username: john-doe
+    password:
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+
+  # test_pool_1_db_c needs to be the last database defined in the file
+  # otherwise the test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
+  # test fails
+  test_pool_1_db_c:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_c
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true


### PR DESCRIPTION
This PR adds support for Rails 6.1 with both `legacy_connection_handling=true` & `legacy_connection_handling=false`

It's tested with the new multiple database functionality for sharded & unsharded models and with both writing and reading roles:

```ruby
class AbstractPool1DbA < ActiveRecord::Base
  self.abstract_class = true
  connects_to database: { writing: :test_pool_1_db_a, reading: :test_pool_1_db_a_replica }
end

class Pool1DbA < AbstractPool1DbA
  self.table_name = "tests"
end

... 

class AbstractShardedModel < ActiveRecord::Base
  self.abstract_class = true
  connects_to shards: {
                default: { writing: :test_pool_1_db_shard_a },
                shard_b: { writing: :test_pool_1_db_shard_b, reading: :test_pool_1_db_shard_b_replica },
                shard_c: { writing: :test_pool_1_db_shard_c, reading: :test_pool_1_db_shard_c_replica },
                shard_d: { writing: :test_pool_2_db_shard_d, reading: :test_pool_2_db_shard_d_replica }
              }
end

class ShardedModel < AbstractShardedModel
  self.table_name = "tests"
end
```

Models with matching hosts, ports, sockets, usernames, and replica status should share a connection and should any of those configuration items differ then they will _not_ share a connection.