### PR TITLE
Some cleanups

### DIFF
--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("mysql2")
 
   s.add_development_dependency("bump")
+  s.add_development_dependency("minitest", ">= 5.10.0")
   s.add_development_dependency("mocha")
   s.add_development_dependency("phenix")
   s.add_development_dependency("rake", '>= 12.0.0')

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("bump")
   s.add_development_dependency("minitest", ">= 5.10.0")
-  s.add_development_dependency("mocha")
+  s.add_development_dependency("mocha", ">= 1.4.0")
   s.add_development_dependency("phenix")
   s.add_development_dependency("rake", '>= 12.0.0')
   s.add_development_dependency('rubocop', '~> 0.80.0')

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -67,6 +67,7 @@ DEPENDENCIES
   activerecord (~> 5.1.6)
   bump
   byebug
+  minitest (>= 5.10.0)
   mocha
   mysql2 (>= 0.3.18, < 0.6.0)
   phenix

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -68,7 +68,7 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
-  mocha
+  mocha (>= 1.4.0)
   mysql2 (>= 0.3.18, < 0.6.0)
   phenix
   rake (>= 12.0.0)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -68,7 +68,7 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
-  mocha
+  mocha (>= 1.4.0)
   mysql2 (>= 0.4.4, < 0.6.0)
   phenix
   rake (>= 12.0.0)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -67,6 +67,7 @@ DEPENDENCIES
   activerecord (~> 5.2.0)
   bump
   byebug
+  minitest (>= 5.10.0)
   mocha
   mysql2 (>= 0.4.4, < 0.6.0)
   phenix

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -68,7 +68,7 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
-  mocha
+  mocha (>= 1.4.0)
   mysql2 (>= 0.4.4)
   phenix
   rake (>= 12.0.0)

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -67,6 +67,7 @@ DEPENDENCIES
   activerecord (~> 6.0.0)
   bump
   byebug
+  minitest (>= 5.10.0)
   mocha
   mysql2 (>= 0.4.4)
   phenix

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,8 +10,6 @@ require 'phenix'
 
 RAILS_ENV = 'test'
 
-Minitest::Test = MiniTest::Unit::TestCase unless defined?(::Minitest::Test)
-
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + '/test.log')
 
 Phenix.configure do |config|

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 
 require 'active_record_host_pool'
 require 'logger'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'phenix'
 
 RAILS_ENV = 'test'


### PR DESCRIPTION
Setting explicit version requirements on Minitest and Mocha, so we can get rid of some old code. Also removing a piece of code necessary only for Rails > 4.1 which we don’t support anymore.