### PR TITLE
Add ruby-core team as default codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @zendesk/database-gem-owners
+* @zendesk/ruby-core @zendesk/database-gem-owners


### PR DESCRIPTION
The ruby-core team are the primary team owners. The database-gem-owners
group remains as it's filled with champions that can push through change
without being blocked by ruby-core.