### PR TITLE
Refactor tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -76,4 +76,16 @@ module ARHPTestSetup
   ensure
     mod.define_method(method_name, method_body)
   end
+
+  def simulate_rails_app_active_record_railties
+    if ActiveRecord.version >= Gem::Version.new('6.0')
+      # Necessary for testing ActiveRecord 6.0 which uses the connection
+      # handlers when clearing query caches across all handlers when
+      # an operation that dirties the cache is involved (e.g. create/insert,
+      # update, delete/destroy, truncate, etc.)
+      ActiveRecord::Base.connection_handlers = {
+        ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler
+      }
+    end
+  end
 end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -215,18 +215,4 @@ class ActiveRecordHostPoolTest < Minitest::Test
     pool.expects(:checkin).with(conn)
     pool.release_connection
   end
-
-  private
-
-  def simulate_rails_app_active_record_railties
-    if ActiveRecord.version >= Gem::Version.new('6.0')
-      # Necessary for testing ActiveRecord 6.0 which uses the connection
-      # handlers when clearing query caches across all handlers when
-      # an operation that dirties the cache is involved (e.g. create/insert,
-      # update, delete/destroy, truncate, etc.)
-      ActiveRecord::Base.connection_handlers = {
-        ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler
-      }
-    end
-  end
 end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -74,33 +74,6 @@ class ActiveRecordHostPoolTest < Minitest::Test
     assert_equal(Pool1DbA.connection.raw_connection, Pool1DbC.connection.raw_connection)
   end
 
-  if ActiveRecord.version >= Gem::Version.new('6.0')
-    def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
-      simulate_rails_app_active_record_railties
-
-      # Remove patch that fixes an issue in Rails 6+ to ensure it still
-      # exists. If this begins to fail then it may mean that Rails has fixed
-      # the issue so that it no longer occurs.
-      without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
-        exception = assert_raises(ActiveRecord::StatementInvalid) do
-          ActiveRecord::Base.cache { Pool1DbC.create! }
-        end
-
-        assert_equal("Mysql2::Error: Table 'arhp_test_db_b.pool1_db_cs' doesn't exist", exception.message)
-      end
-    end
-
-    def test_models_with_matching_hosts_and_non_matching_databases_do_not_mix_up_underlying_database
-      simulate_rails_app_active_record_railties
-
-      # ActiveRecord 6.0 introduced a change that surfaced a problematic code
-      # path in active_record_host_pool when clearing caches across connection
-      # handlers which can cause the database to change.
-      # See ActiveRecordHostPool::ClearQueryCachePatch
-      ActiveRecord::Base.cache { Pool1DbC.create! }
-    end
-  end
-
   def test_connection_returns_a_proxy
     assert_kind_of ActiveRecordHostPool::ConnectionProxy, Pool1DbA.connection
   end
@@ -118,14 +91,6 @@ class ActiveRecordHostPoolTest < Minitest::Test
     refute Pool1DbA.connection.respond_to?(:test_private_method)
     assert_includes(Pool1DbA.connection.private_methods, :test_private_method)
     assert_equal true, Pool1DbA.connection.send(:test_private_method)
-  end
-
-  def test_should_not_share_a_query_cache
-    Pool1DbA.create(val: 'foo')
-    Pool1DbB.create(val: 'foobar')
-    Pool1DbA.connection.cache do
-      refute_equal Pool1DbA.first.val, Pool1DbB.first.val
-    end
   end
 
   def test_object_creation

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -10,6 +10,8 @@ class ActiveRecordHostPoolTest < Minitest::Test
   end
 
   def teardown
+    ActiveRecord::Base.connection.disconnect!
+    ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
     Phenix.burn!
   end
 

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+class ActiveRecordHostCachingTest < Minitest::Test
+  include ARHPTestSetup
+  def setup
+    Phenix.rise!
+    arhp_create_models
+  end
+
+  def teardown
+    ActiveRecord::Base.connection.disconnect!
+    ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
+    Phenix.burn!
+  end
+
+  def test_should_not_share_a_query_cache
+    if ActiveRecord.version >= Gem::Version.new('6.0')
+      ActiveRecord::Base.clear_query_caches_for_current_thread
+    end
+
+    Pool1DbA.create(val: 'foo')
+    Pool1DbB.create(val: 'foobar')
+
+    Pool1DbA.connection.cache do
+      refute_equal Pool1DbA.first.val, Pool1DbB.first.val
+    end
+  end
+
+  if ActiveRecord.version >= Gem::Version.new('6.0')
+    def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
+      simulate_rails_app_active_record_railties
+
+      # Remove patch that fixes an issue in Rails 6+ to ensure it still
+      # exists. If this begins to fail then it may mean that Rails has fixed
+      # the issue so that it no longer occurs.
+      without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
+        exception = assert_raises(ActiveRecord::StatementInvalid) do
+          ActiveRecord::Base.cache { Pool1DbC.create! }
+        end
+
+        cached_db = Pool1DbC.connection.unproxied.pool.connections.first.instance_variable_get(:@_cached_current_database)
+        assert_equal("Mysql2::Error: Table '#{cached_db}.pool1_db_cs' doesn't exist", exception.message)
+      end
+    end
+
+    def test_models_with_matching_hosts_and_non_matching_databases_do_not_mix_up_underlying_database
+      simulate_rails_app_active_record_railties
+      # ActiveRecord will clear the query cache after any action that dirties the cache (create, update, etc)
+      # Because we're testing the patch we want to ensure it runs at least once
+      ActiveRecord::Base.clear_query_caches_for_current_thread
+
+      # ActiveRecord 6.0 introduced a change that surfaced a problematic code
+      # path in active_record_host_pool when clearing caches across connection
+      # handlers which can cause the database to change.
+      # See ActiveRecordHostPool::ClearQueryCachePatch
+      ActiveRecord::Base.cache { Pool1DbC.create! }
+    end
+  end
+end

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -9,6 +9,10 @@ class ActiveRecordHostPoolWrongDBTest < Minitest::Test
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 
+  def teardown
+    Phenix.burn!
+  end
+
   # rake db:create uses a pattern where it tries to connect to a non-existant database.
   # but then we had this left in the connection pool cache.
   def test_connecting_to_wrong_db_first


### PR DESCRIPTION
Separates the caching tests into their own file so we can test them individually if need be.

Move `simulate_rails_app_active_record_railties` into `test/helper.rb` so it can be used in any of the test files.