### PR TITLE
Allow testing Rails 6.1 with legacy_connection_handling = false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
-    name: rake test Gemfile ${{ matrix.gemfile }} and Ruby ${{ matrix.ruby-version }}
+    name: rake test Gemfile ${{ matrix.gemfile }} and Ruby ${{ matrix.ruby-version }} (LCH ${{ matrix.legacy_connection_handling }})
     services:
       mysql:
         image: mysql:5.7
@@ -39,8 +39,11 @@ jobs:
           - rails5.2
           - rails6.0
           - rails6.1
+        legacy_connection_handling:
+          - "true"
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
+      LEGACY_CONNECTION_HANDLING: "${{ matrix.legacy_connection_handling }}"
     steps:
       - uses: zendesk/checkout@v2
       - name: Install Ruby, Bundler and gems

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -10,7 +10,7 @@ module ActiveRecordHostPool
 
         def _host_pool_current_database=(database)
           @_host_pool_current_database = database
-          @config[:database] = _host_pool_current_database if ActiveRecord::VERSION::MAJOR >= 5
+          @config[:database] = _host_pool_current_database
         end
 
         alias_method :execute_without_switching, :execute

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,9 +9,10 @@ require 'mocha/minitest'
 require 'phenix'
 
 ENV['RAILS_ENV'] = 'test'
+ENV['LEGACY_CONNECTION_HANDLING'] = 'true' if ENV['LEGACY_CONNECTION_HANDLING'].nil?
 
 if ActiveRecord.version >= Gem::Version.new('6.1')
-  ActiveRecord::Base.legacy_connection_handling = true
+  ActiveRecord::Base.legacy_connection_handling = (ENV['LEGACY_CONNECTION_HANDLING'] == 'true')
 end
 
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + '/test.log')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,6 +15,9 @@ if ActiveRecord.version >= Gem::Version.new('6.1')
   ActiveRecord::Base.legacy_connection_handling = (ENV['LEGACY_CONNECTION_HANDLING'] == 'true')
 end
 
+RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING =
+  ActiveRecord.version >= Gem::Version.new('6.1') && !ActiveRecord::Base.legacy_connection_handling
+
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + '/test.log')
 
 Phenix.configure do |config|

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -45,10 +45,6 @@ class ActiveRecordHostPoolTest < Minitest::Test
     refute_equal(Pool2DbE.connection.raw_connection, Pool3DbE.connection.raw_connection)
   end
 
-  def test_models_with_different_replica_status_should_not_share_a_connection
-    refute_equal(Pool1DbA.connection.raw_connection, Pool1DbAReplica.connection.raw_connection)
-  end
-
   def test_should_select_on_correct_database
     Pool1DbA.connection.send(:select_all, 'select 1')
     assert_equal 'arhp_test_db_a', current_database(Pool1DbA)
@@ -69,11 +65,6 @@ class ActiveRecordHostPoolTest < Minitest::Test
 
     Pool3DbE.connection.send(:insert, "insert into tests values(NULL, 'foo')")
     assert_equal 'arhp_test_db_e', current_database(Pool3DbE)
-  end
-
-  def test_models_with_matching_hosts_and_non_matching_databases_should_share_a_connection
-    simulate_rails_app_active_record_railties
-    assert_equal(Pool1DbA.connection.raw_connection, Pool1DbC.connection.raw_connection)
   end
 
   def test_connection_returns_a_proxy

--- a/test/test_arhp_legacy_connection_handling_only_tests.rb
+++ b/test/test_arhp_legacy_connection_handling_only_tests.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+unless RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
+  class ActiveRecordHostPoolLegacyConnectiongHandlingTest < Minitest::Test
+    include ARHPTestSetup
+    def setup
+      Phenix.rise!
+      arhp_create_models
+    end
+
+    def teardown
+      ActiveRecord::Base.connection.disconnect!
+      ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
+      Phenix.burn!
+    end
+
+    def test_models_without_matching_replica_status_should_not_share_a_connection
+      refute_equal(Pool1DbA.connection.raw_connection, Pool1DbAReplica.connection.raw_connection)
+    end
+
+    def test_models_with_matching_hosts_and_non_matching_databases_should_share_a_connection
+      simulate_rails_app_active_record_railties
+      assert_equal(Pool1DbA.connection.raw_connection, Pool1DbC.connection.raw_connection)
+    end
+  end
+end


### PR DESCRIPTION
We want to start testing Rails 6.1 with `legacy_connection_handling = false`. This keeps `legacy_connection_handling = true` by default in the CI but it can be passed in as an ENV variable to test it locally.