### PR TITLE
Add support for Rails 6.1 when legacy_connection_handling = false

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,14 @@ jobs:
           - rails6.0
           - rails6.1
         legacy_connection_handling:
-          - "true"
+          - "false"
+        include:
+          - ruby-version: "2.6"
+            gemfile: rails6.1
+            legacy_connection_handling: "true"
+          - ruby-version: "2.7"
+            gemfile: rails6.1
+            legacy_connection_handling: "true"
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       LEGACY_CONNECTION_HANDLING: "${{ matrix.legacy_connection_handling }}"

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for Rails 6.1 (https://github.com/zendesk/active_record_host_pool/pull/82)
 
 ### Removed
-
 - Removed compatibility with Rails 4.2. (https://github.com/zendesk/active_record_host_pool/pull/71)
 - Removed compatibility with Ruby 2.5 and lower. (https://github.com/zendesk/active_record_host_pool/pull/80)
 

--- a/lib/active_record_host_pool/clear_query_cache_patch.rb
+++ b/lib/active_record_host_pool/clear_query_cache_patch.rb
@@ -26,6 +26,15 @@ if ActiveRecord.version >= Gem::Version.new('6.0')
         # restore in case clearing the cache changed the database
         connection.unproxied._host_pool_current_database = host_pool_current_database_was
       end
+
+      def clear_on_handler(handler)
+        handler.all_connection_pools.each do |pool|
+          db_was = pool.connection.unproxied._host_pool_current_database
+          pool.connection.clear_query_cache if pool.active_connection?
+        ensure
+          pool.connection.unproxied._host_pool_current_database = db_was
+        end
+      end
     end
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,44 +30,119 @@ module ARHPTestSetup
   def arhp_create_models
     return if ARHPTestSetup.const_defined?('Pool1DbA')
 
-    eval <<-RUBY
-      # The placement of the Pool1DbC class is important so that its
-      # connection will not be the most recent connection established
-      # for test_pool_1.
-      class Pool1DbC < ::ActiveRecord::Base
-        establish_connection(:test_pool_1_db_c)
-      end
+    if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
+      eval <<-RUBY
+        class AbstractPool1DbC < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_1_db_c }
+        end
 
-      class Pool1DbA < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_1_db_a)
-      end
+        # The placement of the Pool1DbC class is important so that its
+        # connection will not be the most recent connection established
+        # for test_pool_1.
+        class Pool1DbC < AbstractPool1DbC
+        end
 
-      class Pool1DbAReplica < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_1_db_a_replica)
-      end
+        class AbstractPool1DbA < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_1_db_a, reading: :test_pool_1_db_a_replica }
+        end
 
-      class Pool1DbB < ActiveRecord::Base
-        self.table_name =  "tests"
-        establish_connection(:test_pool_1_db_b)
-      end
+        class Pool1DbA < AbstractPool1DbA
+          self.table_name = "tests"
+        end
 
-      class Pool2DbD < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_2_db_d)
-      end
+        class AbstractPool1DbB < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_1_db_b }
+        end
 
-      class Pool2DbE < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_2_db_e)
-      end
+        class Pool1DbB < AbstractPool1DbB
+          self.table_name = "tests"
+        end
 
-      class Pool3DbE < ActiveRecord::Base
-        self.table_name = "tests"
-        establish_connection(:test_pool_3_db_e)
-      end
-    RUBY
+        class AbstractPool2DbD < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_2_db_d }
+        end
+
+        class Pool2DbD < AbstractPool2DbD
+          self.table_name = "tests"
+        end
+
+        class AbstractPool2DbE < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_2_db_e }
+        end
+
+        class Pool2DbE < AbstractPool2DbE
+          self.table_name = "tests"
+        end
+
+        class AbstractPool3DbE < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to database: { writing: :test_pool_3_db_e }
+        end
+
+        class Pool3DbE < AbstractPool3DbE
+          self.table_name = "tests"
+        end
+
+        # Test ARHP with Rails 6.1+ horizontal sharding functionality
+        class AbstractShardedModel < ActiveRecord::Base
+          self.abstract_class = true
+          connects_to shards: {
+                        default: { writing: :test_pool_1_db_shard_a },
+                        shard_b: { writing: :test_pool_1_db_shard_b, reading: :test_pool_1_db_shard_b_replica },
+                        shard_c: { writing: :test_pool_1_db_shard_c, reading: :test_pool_1_db_shard_c_replica },
+                        shard_d: { writing: :test_pool_2_db_shard_d, reading: :test_pool_2_db_shard_d_replica }
+                      }
+        end
+
+        class ShardedModel < AbstractShardedModel
+          self.table_name = "tests"
+        end
+      RUBY
+    else
+      eval <<-RUBY
+        # The placement of the Pool1DbC class is important so that its
+        # connection will not be the most recent connection established
+        # for test_pool_1.
+        class Pool1DbC < ActiveRecord::Base
+          establish_connection(:test_pool_1_db_c)
+        end
+
+        class Pool1DbA < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_1_db_a)
+        end
+
+        class Pool1DbAReplica < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_1_db_a_replica)
+        end
+
+        class Pool1DbB < ActiveRecord::Base
+          self.table_name =  "tests"
+          establish_connection(:test_pool_1_db_b)
+        end
+
+        class Pool2DbD < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_2_db_d)
+        end
+
+        class Pool2DbE < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_2_db_e)
+        end
+
+        class Pool3DbE < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_3_db_e)
+        end
+      RUBY
+    end
   end
 
   def current_database(klass)
@@ -86,11 +161,12 @@ module ARHPTestSetup
   end
 
   def simulate_rails_app_active_record_railties
-    if ActiveRecord.version >= Gem::Version.new('6.0')
+    if ActiveRecord.version >= Gem::Version.new('6.0') && !RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
       # Necessary for testing ActiveRecord 6.0 which uses the connection
       # handlers when clearing query caches across all handlers when
       # an operation that dirties the cache is involved (e.g. create/insert,
       # update, delete/destroy, truncate, etc.)
+      # In Rails 6.1 this is only present when legacy_connection_handling=true
       ActiveRecord::Base.connection_handlers = {
         ActiveRecord::Base.writing_role => ActiveRecord::Base.default_connection_handler
       }

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,6 +20,26 @@ RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING =
 
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + '/test.log')
 
+# BEGIN preventing_writes? patch
+## Rails 6.1 by default does not allow writing to replica databases which prevents
+## us from properly setting up the test databases. This patch is used in test/schema.rb
+## to allow us to write to the replicas but only during migrations
+module ActiveRecordHostPool
+  cattr_accessor :allowing_writes
+  module PreventWritesPatch
+    def preventing_writes?
+      return false if ActiveRecordHostPool.allowing_writes && replica?
+
+      super
+    end
+  end
+end
+
+if ActiveRecord.version >= Gem::Version.new('6.1')
+  ActiveRecord::ConnectionAdapters::AbstractAdapter.prepend ActiveRecordHostPool::PreventWritesPatch
+end
+# END preventing_writes? patch
+
 Phenix.configure do |config|
   config.skip_database = ->(name, conf) { name =~ /not_there/ || conf['username'] == 'john-doe' }
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,16 +1,23 @@
 # frozen_string_literal: true
 
 require_relative 'helper'
-ActiveRecord::Schema.define(version: 1) do
-  create_table 'tests', force: true do |t|
-    t.string   'val'
-  end
 
-  # Add a table only the shard database will have. Conditional
-  # exists since Phenix loads the schema file for every database.
-  if ActiveRecord::Base.connection.current_database == 'arhp_test_db_c'
-    create_table 'pool1_db_cs' do |t|
-      t.string 'name'
+begin
+  ActiveRecordHostPool.allowing_writes = true
+
+  ActiveRecord::Schema.define(version: 1) do
+    create_table 'tests', force: true do |t|
+      t.string   'val'
+    end
+
+    # Add a table only the shard database will have. Conditional
+    # exists since Phenix loads the schema file for every database.
+    if ActiveRecord::Base.connection.current_database == 'arhp_test_db_c'
+      create_table 'pool1_db_cs' do |t|
+        t.string 'name'
+      end
     end
   end
+ensure
+  ActiveRecordHostPool.allowing_writes = false
 end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -5,7 +5,11 @@ require_relative 'helper'
 class ActiveRecordHostPoolTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    Phenix.rise!
+    if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
+      Phenix.rise! config_path: 'test/three_tier_database.yml'
+    else
+      Phenix.rise!
+    end
     arhp_create_models
   end
 

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -5,7 +5,11 @@ require_relative 'helper'
 class ActiveRecordHostCachingTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    Phenix.rise!
+    if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
+      Phenix.rise! config_path: 'test/three_tier_database.yml'
+    else
+      Phenix.rise!
+    end
     arhp_create_models
   end
 

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -36,16 +36,26 @@ class ActiveRecordHostCachingTest < Minitest::Test
     def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
       simulate_rails_app_active_record_railties
 
+      # Reset the connections post-setup so that we ensure the last DB isn't arhp_test_db_c
+      ActiveRecord::Base.connection.discard!
+      ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
+      ActiveRecord::Base.establish_connection(:test_pool_1_db_a)
+
+      # Ensure this works _with_ the patch
+      ActiveRecord::Base.cache { Pool1DbC.create! }
+
       # Remove patch that fixes an issue in Rails 6+ to ensure it still
       # exists. If this begins to fail then it may mean that Rails has fixed
       # the issue so that it no longer occurs.
       without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_query_caches_for_current_thread) do
-        exception = assert_raises(ActiveRecord::StatementInvalid) do
-          ActiveRecord::Base.cache { Pool1DbC.create! }
-        end
+        without_module_patch(ActiveRecordHostPool::ClearQueryCachePatch, :clear_on_handler) do
+          exception = assert_raises(ActiveRecord::StatementInvalid) do
+            ActiveRecord::Base.cache { Pool1DbC.create! }
+          end
 
-        cached_db = Pool1DbC.connection.unproxied.pool.connections.first.instance_variable_get(:@_cached_current_database)
-        assert_equal("Mysql2::Error: Table '#{cached_db}.pool1_db_cs' doesn't exist", exception.message)
+          cached_db = Pool1DbC.connection.unproxied.pool.connections.first.instance_variable_get(:@_cached_current_database)
+          assert_equal("Mysql2::Error: Table '#{cached_db}.pool1_db_cs' doesn't exist", exception.message)
+        end
       end
     end
 

--- a/test/test_arhp_with_non_legacy_connection_handling.rb
+++ b/test/test_arhp_with_non_legacy_connection_handling.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require_relative 'helper'
+
+if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
+  class ActiveRecordHostPoolTestWithNonlegacyConnectionHandling < Minitest::Test
+    include ARHPTestSetup
+    def setup
+      Phenix.rise! config_path: 'test/three_tier_database.yml'
+      arhp_create_models
+    end
+
+    def teardown
+      ActiveRecord::Base.connection.disconnect!
+      ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
+      Phenix.burn!
+    end
+
+    def test_correctly_writes_to_sharded_databases
+      AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
+        ShardedModel.create!
+        ShardedModel.create!
+      end
+
+      AbstractShardedModel.connected_to(role: :writing, shard: :shard_d) do
+        ShardedModel.create!
+      end
+
+      # Normally we would count the records using the replicas (`reading` role).
+      # However, ActiveRecord does not mirror data from the writing DB onto the
+      # replica database(s) for you so apps must implement that themselves.
+      # Therefore, for testing purposes, we count the records on the writer db.
+      records_on_shard_b = AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
+        ShardedModel.count
+      end
+
+      records_on_shard_d = AbstractShardedModel.connected_to(role: :writing, shard: :shard_d) do
+        ShardedModel.count
+      end
+
+      assert_equal 2, records_on_shard_b
+      assert_equal 1, records_on_shard_d
+      assert_equal 0, ShardedModel.count
+    end
+
+    def test_shards_with_matching_hosts_ports_sockets_usernames_and_replica_status_should_share_a_connection
+      default_shard_connection = ShardedModel.connection.raw_connection
+      pool_1_shard_b_writing_connection = AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
+        ShardedModel.connection.raw_connection
+      end
+      pool_1_shard_b_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_b) do
+        ShardedModel.connection.raw_connection
+      end
+      pool_1_shard_c_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_c) do
+        ShardedModel.connection.raw_connection
+      end
+
+      assert_equal(default_shard_connection, pool_1_shard_b_writing_connection)
+      assert_equal(pool_1_shard_b_reading_connection, pool_1_shard_c_reading_connection)
+    end
+
+    def test_shards_without_matching_ports_should_not_share_a_connection
+      default_shard_connection = ShardedModel.connection.raw_connection
+      pool_1_shard_b_writing_connection = AbstractShardedModel.connected_to(role: :writing, shard: :shard_b) do
+        ShardedModel.connection.raw_connection
+      end
+      pool_2_shard_d_writing_connection = AbstractShardedModel.connected_to(role: :writing, shard: :shard_d) do
+        ShardedModel.connection.raw_connection
+      end
+
+      refute_equal(default_shard_connection, pool_2_shard_d_writing_connection)
+      refute_equal(pool_1_shard_b_writing_connection, pool_2_shard_d_writing_connection)
+    end
+
+    # The role name for a writer database is :writing
+    # The role name for a replica/reader database is :reading
+    def test_writers_should_not_share_a_connection_with_replicas
+      refute_equal(
+        (AbstractPool1DbA.connected_to(role: :writing) { Pool1DbA.connection.raw_connection }),
+        (AbstractPool1DbA.connected_to(role: :reading) { Pool1DbA.connection.raw_connection })
+      )
+    end
+
+    def test_sharded_reading_and_writing_roles_should_not_share_a_connection
+      shard_c_writing_connection = AbstractShardedModel.connected_to(role: :writing, shard: :shard_c) do
+        ShardedModel.connection.raw_connection
+      end
+      shard_c_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_c) do
+        ShardedModel.connection.raw_connection
+      end
+
+      refute_equal(shard_c_writing_connection, shard_c_reading_connection)
+    end
+
+    def test_sharded_reading_roles_without_matching_ports_should_not_share_a_connection
+      shard_c_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_c) do
+        ShardedModel.connection.raw_connection
+      end
+      shard_d_reading_connection = AbstractShardedModel.connected_to(role: :reading, shard: :shard_d) do
+        ShardedModel.connection.raw_connection
+      end
+
+      refute_equal(shard_c_reading_connection, shard_d_reading_connection)
+    end
+  end
+end

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -5,7 +5,11 @@ require_relative 'helper'
 class ActiveRecordHostPoolWrongDBTest < Minitest::Test
   include ARHPTestSetup
   def setup
-    Phenix.load_database_config
+    if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
+      Phenix.load_database_config 'test/three_tier_database.yml'
+    else
+      Phenix.load_database_config
+    end
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 

--- a/test/three_tier_database.yml
+++ b/test/three_tier_database.yml
@@ -1,0 +1,181 @@
+<% mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306') %>
+
+# This .yml file is loaded in Rails 6.1 when ActiveRecord::Base.legacy_connection_handling = false
+#
+# ARHP creates separate connection pools based on the pool key.
+# The pool key is defined as:
+#   host / port / socket / username / replica
+#
+# Therefore two databases with identical host, port, socket, username, and replica status will share a connection pool.
+# If any part (host, port, etc.) of the pool key differ, two databases will _not_ share a connection pool.
+#
+# `replica` in the pool key is a boolean indicating if the database is a replica/reader (true) or writer database (false).
+# In Rails 6.1 models when you call:
+#  `connected_to(role: :writing)` it will access the writer/primary database
+#
+#  `connected_to(role: :reading)` it will access the replica/reader database
+#
+# Below, `test_pool_1...` and `test_pool_2...` have identical host, username, socket, and replica status but the port information differs.
+# Here the database configurations are formatted as a table to give a visual example:
+#
+# |          |  test_pool_1   |  test_pool_2   |
+# |----------|----------------|----------------|
+# | host     | 127.0.0.1      | 127.0.0.1      |
+# | port     |                | 3306           |
+# | socket   |                |                |
+# | username | root           | root           |
+# | replica  | false          | false          |
+#
+# The configuration items must be explicitly defined or they will be blank in the pool key.
+# Configurations with matching _implicit_ items but differing _explicit_ items will create separate pools.
+# e.g. `test_pool_1` will default to port 3306 but because it is not explicitly defined it will not share a pool with `test_pool_2`
+#
+# ARHP will therefore create the following pool keys:
+#   test_pool_1 => 127.0.0.1///root/false
+#   test_pool_2 => 127.0.0.1/3306//root/false
+
+test:
+  test_pool_1_db_a:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_a
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  # Mimic configurations as read by active_record_shards/ar_flexmaster
+  test_pool_1_db_a_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_a_replica
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+    replica: true
+
+  test_pool_1_db_b:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_b
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_c:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_c
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_not_there:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_not_there
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_shard_a:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_a
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_shard_b:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_b
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_shard_b_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_b_replica
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+    replica: true
+
+  test_pool_1_db_shard_c:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_c
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+
+  test_pool_1_db_shard_c_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_c_replica
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    reconnect: true
+    replica: true
+
+  test_pool_2_db_shard_d:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_d
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+
+  test_pool_2_db_shard_d_replica:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_shard_d_replica
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+    replica: true
+
+  test_pool_2_db_d:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_d
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+
+  test_pool_2_db_e:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_e
+    username: <%= mysql.user %>
+    password: <%= mysql.password %>
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true
+
+  test_pool_3_db_e:
+    adapter: mysql2
+    encoding: utf8
+    database: arhp_test_db_e
+    username: john-doe
+    password:
+    host: <%= mysql.host %>
+    port: <%= mysql.port %>
+    reconnect: true


### PR DESCRIPTION
### Overview

This PR adds support for Rails 6.1 when `legacy_connection_handling=false`

It's tested with the new multiple database functionality for sharded & unsharded models and with both writing and reading roles:

```ruby
class AbstractPool1DbA < ActiveRecord::Base
  self.abstract_class = true
  connects_to database: { writing: :test_pool_1_db_a, reading: :test_pool_1_db_a_replica }
end

class Pool1DbA < AbstractPool1DbA
  self.table_name = "tests"
end

... 

class AbstractShardedModel < ActiveRecord::Base
  self.abstract_class = true
  connects_to shards: {
                default: { writing: :test_pool_1_db_shard_a },
                shard_b: { writing: :test_pool_1_db_shard_b, reading: :test_pool_1_db_shard_b_replica },
                shard_c: { writing: :test_pool_1_db_shard_c, reading: :test_pool_1_db_shard_c_replica },
                shard_d: { writing: :test_pool_2_db_shard_d, reading: :test_pool_2_db_shard_d_replica }
              }
end

class ShardedModel < AbstractShardedModel
  self.table_name = "tests"
end
```

Models with matching hosts, ports, sockets, usernames, and replica status should share a connection and should any of those configuration items differ then they will not share a connection.

### clear_on_handler patch

We're are now patching `#clear_on_handler`:

```ruby
def clear_on_handler(handler)
  handler.all_connection_pools.each do |pool|
    db_was = pool.connection.unproxied._host_pool_current_database
    pool.connection.clear_query_cache if pool.active_connection?
  ensure
    pool.connection.unproxied._host_pool_current_database = db_was
  end
end
```
When Rails calls `#clear_query_caches_for_current_thread` we end up in `#clear_on_handler`.

Clear on handler will loop through every connection pool () and call `pool.connection` on it. 

`pool.connection` is a problem because ARHP patches connection to call `select_db` on that current database host and thus we're we clear the query caches we are switching to a new database on every real connection.

We can then end up on a database we don't expect and therefore we switch back to avoid conflicts.