### PR TITLE
Add missing files into the shipped gem

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [1.1.1] - 2022-08-26
+### Fixed
+- Ensure that recently added files "lib/active_record_host_pool/pool_proxy_6_1.rb" and "lib/active_record_host_pool/pool_proxy_legacy.rb" are built into the shipped gem. (https://github.com/zendesk/active_record_host_pool/pull/92)
+
 ## [1.1.0] - 2022-08-26
 ### Added
 - Support for Rails 6.1 with [legacy_connection_handling=false](https://github.com/zendesk/active_record_host_pool/pull/90) and [legacy_connection_handling=true](https://github.com/zendesk/active_record_host_pool/pull/88)

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
     "lib/active_record_host_pool/connection_adapter_mixin.rb",
     "lib/active_record_host_pool/connection_proxy.rb",
     "lib/active_record_host_pool/pool_proxy.rb",
+    "lib/active_record_host_pool/pool_proxy_6_1.rb",
+    "lib/active_record_host_pool/pool_proxy_legacy.rb",
     "lib/active_record_host_pool/version.rb"
   ]
   s.homepage = "https://github.com/zendesk/active_record_host_pool"

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.1.0)
+    active_record_host_pool (1.1.1)
       activerecord (>= 5.1.0, < 7.0)
       mysql2
 

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.1.0)
+    active_record_host_pool (1.1.1)
       activerecord (>= 5.1.0, < 7.0)
       mysql2
 

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.1.0)
+    active_record_host_pool (1.1.1)
       activerecord (>= 5.1.0, < 7.0)
       mysql2
 

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.1.0)
+    active_record_host_pool (1.1.1)
       activerecord (>= 5.1.0, < 7.0)
       mysql2
 

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
Ensure that recently added files "lib/active_record_host_pool/pool_proxy_6_1.rb" and "lib/active_record_host_pool/pool_proxy_legacy.rb" are built into the shipped gem.