### PR TITLE
Test Rails 6.1 with Ruby 3.0 & 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
         ruby-version:
           - 2.6
           - 2.7
+          - 3.0
         gemfile:
           - rails5.1
           - rails5.2
@@ -48,6 +49,16 @@ jobs:
           - ruby-version: "2.7"
             gemfile: rails6.1
             legacy_connection_handling: "true"
+          - ruby-version: "3.0"
+            gemfile: rails6.1
+            legacy_connection_handling: "true"
+        exclude:
+          - ruby-version: "3.0"
+            gemfile: rails5.1
+          - ruby-version: "3.0"
+            gemfile: rails5.2
+          - ruby-version: "3.0"
+            gemfile: rails6.0
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       LEGACY_CONNECTION_HANDLING: "${{ matrix.legacy_connection_handling }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           - 2.6
           - 2.7
           - 3.0
+          - 3.1
         gemfile:
           - rails5.1
           - rails5.2
@@ -52,12 +53,21 @@ jobs:
           - ruby-version: "3.0"
             gemfile: rails6.1
             legacy_connection_handling: "true"
+          - ruby-version: "3.1"
+            gemfile: rails6.1
+            legacy_connection_handling: "true"
         exclude:
           - ruby-version: "3.0"
             gemfile: rails5.1
           - ruby-version: "3.0"
             gemfile: rails5.2
           - ruby-version: "3.0"
+            gemfile: rails6.0
+          - ruby-version: "3.1"
+            gemfile: rails5.1
+          - ruby-version: "3.1"
+            gemfile: rails5.2
+          - ruby-version: "3.1"
             gemfile: rails6.0
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Start testing with Ruby 3.0 & 3.1
 
 ## [1.1.1] - 2022-08-26
 ### Fixed


### PR DESCRIPTION
Start testing Rails 6.1 with Ruby 3.0 and 3.1