### PR TITLE
Set gem_push to false

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,9 @@ require 'rake/testtask'
 require 'bump/tasks'
 require 'rubocop/rake_task'
 
+# Pushing to rubygems is handled by a github workflow
+ENV['gem_push'] = 'false'
+
 Rake::TestTask.new do |test|
   test.pattern = 'test/test_*.rb'
   test.verbose = true


### PR DESCRIPTION
Calling `rake release` will:
  - build
  - tag (if everything has been committed)
  - push to the repo
  - push the gem to rubygems

Setting gem_push to false will skip the last step. We want to skip this because this is handled by a github workflow instead.

Co-authored-by: Benjamin Quorning <bquorning@zendesk.com>