### PR TITLE
Rethink test gems

### DIFF
--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -37,5 +37,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency("phenix", ">= 1.0.1")
   s.add_development_dependency("rake", '>= 12.0.0')
   s.add_development_dependency('rubocop', '~> 0.80.0')
-  s.add_development_dependency("shoulda")
 end

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("bump")
   s.add_development_dependency("minitest", ">= 5.10.0")
-  s.add_development_dependency("mocha", ">= 1.4.0")
+  s.add_development_dependency("minitest-mock_expectations", "~> 1.1.3")
   s.add_development_dependency("phenix", ">= 1.0.1")
   s.add_development_dependency("rake", '>= 12.0.0')
   s.add_development_dependency('rubocop', '~> 0.80.0')

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -48,12 +48,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    shoulda (3.6.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (~> 3.0)
-    shoulda-context (1.2.2)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
@@ -73,7 +67,6 @@ DEPENDENCIES
   phenix (>= 1.0.1)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
-  shoulda
 
 BUNDLED WITH
    2.3.7

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -28,7 +28,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     minitest (5.16.3)
-    mocha (1.11.2)
+    minitest-mock_expectations (1.1.3)
     mysql2 (0.5.3)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -62,7 +62,7 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
-  mocha (>= 1.4.0)
+  minitest-mock_expectations (~> 1.1.3)
   mysql2 (>= 0.3.18, < 0.6.0)
   phenix (>= 1.0.1)
   rake (>= 12.0.0)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -28,7 +28,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     minitest (5.16.3)
-    mocha (1.11.2)
+    minitest-mock_expectations (1.1.3)
     mysql2 (0.5.3)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -62,7 +62,7 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
-  mocha (>= 1.4.0)
+  minitest-mock_expectations (~> 1.1.3)
   mysql2 (>= 0.4.4, < 0.6.0)
   phenix (>= 1.0.1)
   rake (>= 12.0.0)

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -48,12 +48,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    shoulda (3.6.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (~> 3.0)
-    shoulda-context (1.2.2)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
@@ -73,7 +67,6 @@ DEPENDENCIES
   phenix (>= 1.0.1)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
-  shoulda
 
 BUNDLED WITH
    2.3.7

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -27,7 +27,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     minitest (5.16.3)
-    mocha (1.11.2)
+    minitest-mock_expectations (1.1.3)
     mysql2 (0.5.3)
     parallel (1.19.1)
     parser (2.7.0.2)
@@ -62,7 +62,7 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
-  mocha (>= 1.4.0)
+  minitest-mock_expectations (~> 1.1.3)
   mysql2 (>= 0.4.4)
   phenix (>= 1.0.1)
   rake (>= 12.0.0)

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -47,12 +47,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
-    shoulda (3.6.0)
-      shoulda-context (~> 1.0, >= 1.0.1)
-      shoulda-matchers (~> 3.0)
-    shoulda-context (1.2.2)
-    shoulda-matchers (3.1.3)
-      activesupport (>= 4.0.0)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
@@ -73,7 +67,6 @@ DEPENDENCIES
   phenix (>= 1.0.1)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
-  shoulda
 
 BUNDLED WITH
    2.3.7

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -27,7 +27,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     minitest (5.16.3)
-    mocha (1.14.0)
+    minitest-mock_expectations (1.1.3)
     mysql2 (0.5.4)
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -61,7 +61,7 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
-  mocha (>= 1.4.0)
+  minitest-mock_expectations (~> 1.1.3)
   mysql2 (~> 0.5)
   phenix (>= 1.0.1)
   rake (>= 12.0.0)

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -47,12 +47,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.11.0)
-    shoulda (4.0.0)
-      shoulda-context (~> 2.0)
-      shoulda-matchers (~> 4.0)
-    shoulda-context (2.0.0)
-    shoulda-matchers (4.5.1)
-      activesupport (>= 4.2.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
@@ -72,7 +66,6 @@ DEPENDENCIES
   phenix (>= 1.0.1)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
-  shoulda
 
 BUNDLED WITH
    2.3.7

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -46,12 +46,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.11.0)
-    shoulda (4.0.0)
-      shoulda-context (~> 2.0)
-      shoulda-matchers (~> 4.0)
-    shoulda-context (2.0.0)
-    shoulda-matchers (4.5.1)
-      activesupport (>= 4.2.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
@@ -70,7 +64,6 @@ DEPENDENCIES
   phenix (>= 1.0.1)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
-  shoulda
 
 BUNDLED WITH
    2.3.7

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -26,7 +26,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     minitest (5.16.3)
-    mocha (1.15.0)
+    minitest-mock_expectations (1.1.3)
     mysql2 (0.5.4)
     parallel (1.22.1)
     parser (3.1.2.1)
@@ -59,7 +59,7 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
-  mocha (>= 1.4.0)
+  minitest-mock_expectations (~> 1.1.3)
   mysql2 (>= 0.4.4)
   phenix (>= 1.0.1)
   rake (>= 12.0.0)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,7 +5,7 @@ require 'minitest/autorun'
 
 require 'active_record_host_pool'
 require 'logger'
-require 'mocha/minitest'
+require 'minitest/mock_expectations'
 require 'phenix'
 
 ENV['RAILS_ENV'] = 'test'


### PR DESCRIPTION
This PR removes the gems Shoulda and Mocha. I think Shoulda was actually never used and as for Mocha… We can easily use Minitest‘s own `#stub` method instead of Mocha’s `#stubs`, and the [minitest-mock_expectations](https://github.com/bogdanvlviv/minitest-mock_expectations) gem is a way, way smaller dependency than Mocha and yet it provides just the right amount of “syntactic sugar” for mocking. Methods like `refute_called`, `assert_called` and `assert_called_with`.
