### PR TITLE
Splat kwargs on #execute

### DIFF
--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -33,11 +33,11 @@ module ActiveRecordHostPool
     end
 
     def self.ruby2_keywords(*); end unless respond_to?(:ruby2_keywords, true)
-    ruby2_keywords def execute_with_switching(*args)
+    ruby2_keywords def execute_with_switching(*args, **kwargs)
       if _host_pool_current_database && !_no_switch
         _switch_connection
       end
-      execute_without_switching(*args)
+      execute_without_switching(*args, **kwargs)
     end
 
     def drop_database_with_no_switching(*args)


### PR DESCRIPTION
Rails 7 introduced an `async` keyword argument to the `#execute` method so we get keyword errors unless we splat in the kwargs:

```ruby
  # activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb

  def execute(sql, name = nil, async: false)
    raw_execute(sql, name, async: async)
  end
```