### PR TITLE
Fix ActiveRecord::Base.clear_on_handler

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,12 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Added
+- Add a new `ActiveRecordHostPool::PoolProxy#_unproxied_connection` method which gives access to the underlying, "real", shared connection without going through the connection proxy, which would call `#_host_pool_current_database=` on the underlying connection. (https://github.com/zendesk/active_record_host_pool/pull/104)
+
+### Fixed
+- Fix the patch for `ActiveRecord::Base.clear_on_handler` to work correctly right after the creation of a new connection pool. (https://github.com/zendesk/active_record_host_pool/pull/104)
+
 ## [1.2.1] - 2022-12-23
 ### Fixed
 - Fix forwarding of kwargs when calling `#execute` in Rails 7. (https://github.com/zendesk/active_record_host_pool/pull/101)

--- a/lib/active_record_host_pool/clear_query_cache_patch.rb
+++ b/lib/active_record_host_pool/clear_query_cache_patch.rb
@@ -29,10 +29,10 @@ if ActiveRecord.version >= Gem::Version.new('6.0')
 
       def clear_on_handler(handler)
         handler.all_connection_pools.each do |pool|
-          db_was = pool.connection.unproxied._host_pool_current_database
-          pool.connection.clear_query_cache if pool.active_connection?
+          db_was = pool._unproxied_connection._host_pool_current_database
+          pool._unproxied_connection.clear_query_cache if pool.active_connection?
         ensure
-          pool.connection.unproxied._host_pool_current_database = db_was
+          pool._unproxied_connection._host_pool_current_database = db_was
         end
       end
     end

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -8,11 +8,6 @@ module ActiveRecordHostPool
       base.class_eval do
         attr_reader(:_host_pool_current_database)
 
-        def _host_pool_current_database=(database)
-          @_host_pool_current_database = database
-          @config[:database] = _host_pool_current_database
-        end
-
         alias_method :execute_without_switching, :execute
         alias_method :execute, :execute_with_switching
 
@@ -30,6 +25,11 @@ module ActiveRecordHostPool
     def initialize(*)
       @_cached_current_database = nil
       super
+    end
+
+    def _host_pool_current_database=(database)
+      @_host_pool_current_database = database
+      @config[:database] = _host_pool_current_database
     end
 
     def self.ruby2_keywords(*); end unless respond_to?(:ruby2_keywords, true)

--- a/lib/active_record_host_pool/pool_proxy_6_1.rb
+++ b/lib/active_record_host_pool/pool_proxy_6_1.rb
@@ -34,11 +34,15 @@ module ActiveRecordHostPool
     attr_reader :pool_config
 
     def connection(*args)
-      real_connection = _connection_pool.connection(*args)
+      real_connection = _unproxied_connection(*args)
       _connection_proxy_for(real_connection, @config[:database])
     rescue Mysql2::Error, ActiveRecord::NoDatabaseError
       _connection_pools.delete(_pool_key)
       Kernel.raise
+    end
+
+    def _unproxied_connection(*args)
+      _connection_pool.connection(*args)
     end
 
     # by the time we are patched into ActiveRecord, the current thread has already established

--- a/lib/active_record_host_pool/pool_proxy_legacy.rb
+++ b/lib/active_record_host_pool/pool_proxy_legacy.rb
@@ -36,11 +36,15 @@ module ActiveRecordHostPool
     attr_reader :spec
 
     def connection(*args)
-      real_connection = _connection_pool.connection(*args)
+      real_connection = _unproxied_connection(*args)
       _connection_proxy_for(real_connection, @config[:database])
     rescue Mysql2::Error, ActiveRecord::NoDatabaseError
       _connection_pools.delete(_pool_key)
       Kernel.raise
+    end
+
+    def _unproxied_connection(*args)
+      _connection_pool.connection(*args)
     end
 
     # by the time we are patched into ActiveRecord, the current thread has already established


### PR DESCRIPTION
Fix the patch for `ActiveRecord::Base.clear_on_handler` to work correctly right after the creation of a new connection pool.

In doing this, we add `ActiveRecordHostPool::PoolProxy#_unproxied_connection` which gives access to the underlying, "real", shared connection without going through the connection proxy, which would call `#_host_pool_current_database=` on the underlying connection.
