### PR TITLE
Fix clear_query_caches_for_current_thread

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [1.2.3] - 2023-01-19
 ### Fixed
 - Fix the patch for `ActiveRecord::Base.clear_query_caches_for_current_thread` to work correctly right after the creation of a new connection pool. (https://github.com/zendesk/active_record_host_pool/pull/105)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Fixed
+- Fix the patch for `ActiveRecord::Base.clear_query_caches_for_current_thread` to work correctly right after the creation of a new connection pool. (https://github.com/zendesk/active_record_host_pool/pull/105)
+
 ## [1.2.2] - 2023-01-18
 ### Added
 - Add a new `ActiveRecordHostPool::PoolProxy#_unproxied_connection` method which gives access to the underlying, "real", shared connection without going through the connection proxy, which would call `#_host_pool_current_database=` on the underlying connection. (https://github.com/zendesk/active_record_host_pool/pull/104)

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.2)
+    active_record_host_pool (1.2.3)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -69,4 +69,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.3.7
+   2.4.2

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.2)
+    active_record_host_pool (1.2.3)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -69,4 +69,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.3.7
+   2.4.2

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.2)
+    active_record_host_pool (1.2.3)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -69,4 +69,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.3.7
+   2.4.2

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.2)
+    active_record_host_pool (1.2.3)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -68,4 +68,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.3.7
+   2.4.2

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.2)
+    active_record_host_pool (1.2.3)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -66,4 +66,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.3.7
+   2.4.2

--- a/lib/active_record_host_pool/clear_query_cache_patch.rb
+++ b/lib/active_record_host_pool/clear_query_cache_patch.rb
@@ -20,11 +20,11 @@ if ActiveRecord.version >= Gem::Version.new('6.0')
     # actively working on sharding in Rails 6 and above.
     module ClearQueryCachePatch
       def clear_query_caches_for_current_thread
-        host_pool_current_database_was = connection.unproxied._host_pool_current_database
+        host_pool_current_database_was = connection_pool._unproxied_connection._host_pool_current_database
         super
       ensure
         # restore in case clearing the cache changed the database
-        connection.unproxied._host_pool_current_database = host_pool_current_database_was
+        connection_pool._unproxied_connection._host_pool_current_database = host_pool_current_database_was
       end
 
       def clear_on_handler(handler)

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "1.2.2"
+  VERSION = "1.2.3"
 end


### PR DESCRIPTION
Fix the patch for `ActiveRecord::Base.clear_query_caches_for_current_thread` to work correctly right after the creation of a new connection pool.

