### PR TITLE
Simplify clear_query_cache_patch

### DIFF
--- a/lib/active_record_host_pool/clear_query_cache_patch.rb
+++ b/lib/active_record_host_pool/clear_query_cache_patch.rb
@@ -1,42 +1,46 @@
 # frozen_string_literal: true
 
-if ActiveRecord.version >= Gem::Version.new('6.0')
-  module ActiveRecordHostPool
-    # ActiveRecord 6.0 introduced multiple database support. With that, an update
-    # has been made in https://github.com/rails/rails/pull/35089 to ensure that
-    # all query caches are cleared across connection handlers and pools. If you
-    # write on one connection, the other connection will have the update that
-    # occurred.
-    #
-    # This broke ARHP which implements its own pool, allowing you to access
-    # multiple databases with the same connection (e.g. 1 connection for 100
-    # shards on the same server).
-    #
-    # This patch maintains the reference to the database during the cache clearing
-    # to ensure that the database doesn't get swapped out mid-way into an
-    # operation.
-    #
-    # This is a private Rails API and may change in future releases as they're
-    # actively working on sharding in Rails 6 and above.
-    module ClearQueryCachePatch
-      def clear_query_caches_for_current_thread
-        host_pool_current_database_was = connection_pool._unproxied_connection._host_pool_current_database
-        super
-      ensure
-        # restore in case clearing the cache changed the database
-        connection_pool._unproxied_connection._host_pool_current_database = host_pool_current_database_was
-      end
-
-      def clear_on_handler(handler)
-        handler.all_connection_pools.each do |pool|
-          db_was = pool._unproxied_connection._host_pool_current_database
-          pool._unproxied_connection.clear_query_cache if pool.active_connection?
-        ensure
-          pool._unproxied_connection._host_pool_current_database = db_was
-        end
+# ActiveRecord 6.0 introduced multiple database support. With that, an update
+# has been made in https://github.com/rails/rails/pull/35089 to ensure that
+# all query caches are cleared across connection handlers and pools. If you
+# write on one connection, the other connection will have the update that
+# occurred.
+#
+# This broke ARHP which implements its own pool, allowing you to access
+# multiple databases with the same connection (e.g. 1 connection for 100
+# shards on the same server).
+#
+# This patch maintains the reference to the database during the cache clearing
+# to ensure that the database doesn't get swapped out mid-way into an
+# operation.
+#
+# This is a private Rails API and may change in future releases as they're
+# actively working on sharding in Rails 6 and above.
+module ActiveRecordHostPool
+  # For Rails 6.1 & 7.0.
+  module ClearOnHandlerPatch
+    def clear_on_handler(handler)
+      handler.all_connection_pools.each do |pool|
+        pool._unproxied_connection.clear_query_cache if pool.active_connection?
       end
     end
   end
 
-  ActiveRecord::Base.singleton_class.prepend ActiveRecordHostPool::ClearQueryCachePatch
+  # For Rails 6.0.
+  module ClearQueryCachePatch
+    def clear_query_caches_for_current_thread
+      ActiveRecord::Base.connection_handlers.each_value do |handler|
+        handler.connection_pool_list.each do |pool|
+          pool._unproxied_connection.clear_query_cache if pool.active_connection?
+        end
+      end
+    end
+  end
+end
+
+case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+when '6.1', '7.0'
+  ActiveRecord::Base.singleton_class.prepend(ActiveRecordHostPool::ClearOnHandlerPatch)
+when '6.0'
+  ActiveRecord::Base.singleton_class.prepend(ActiveRecordHostPool::ClearQueryCachePatch)
 end


### PR DESCRIPTION
I believe the underlying problem is that Rails calls `clear_query_caches_for_current_thread` and thus `pool.connection` in the middle of a database transaction. Because `pool.connection` hits the `ConnectionProxy` we end up setting `_host_pool_current_database` and possibly switching databases under us.

Instead of calling `connection` on pool we can call `_unproxied_connection` to bypass the connection proxy and let Rails do its thing without switching dbs.

We only need to patch `clear_query_caches_for_current_thread` in Rails 6.0 because this is the entire method:

```ruby
# activerecord/lib/active_record/connection_handling.rb

def clear_query_caches_for_current_thread
  ActiveRecord::Base.connection_handlers.each_value do |handler|
    handler.connection_pool_list.each do |pool|
      pool.connection.clear_query_cache if pool.active_connection?
    end
  end
end
```

For Rails 6.1 & 7.0 the `clear_query_caches_for_current_thread` method calls `clear_on_handler` which is where `pool.connection` is called:

```ruby
# activerecord/lib/active_record/connection_handling.rb

def clear_query_caches_for_current_thread
  if ActiveRecord.legacy_connection_handling
    ActiveRecord::Base.connection_handlers.each_value do |handler|
      clear_on_handler(handler)
    end
  else
    clear_on_handler(ActiveRecord::Base.connection_handler)
  end
end

def clear_on_handler(handler)
  handler.all_connection_pools.each do |pool|
    pool.connection.clear_query_cache if pool.active_connection?
  end
end
```

Therefore we only need to patch `clear_on_handler` for Rails 6.1 & 7.0. We also [now have a test](https://github.com/zendesk/active_record_host_pool/blob/master/test/test_arhp_with_non_legacy_connection_handling.rb#L20) to catch if db switches happen unexpectedly.