### PR TITLE
Add some gems for test/development

### DIFF
--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -33,8 +33,11 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("bump")
   s.add_development_dependency("minitest", ">= 5.10.0")
+  s.add_development_dependency("minitest-fail-fast")
+  s.add_development_dependency("minitest-line")
   s.add_development_dependency("minitest-mock_expectations", "~> 1.1.3")
   s.add_development_dependency("phenix", ">= 1.0.1")
+  s.add_development_dependency("pry-byebug", "~> 3.9")
   s.add_development_dependency("rake", '>= 12.0.0')
   s.add_development_dependency('rubocop', '~> 0.80.0')
 end

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -23,11 +23,17 @@ GEM
     ast (2.4.0)
     bump (0.9.0)
     byebug (11.1.1)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    method_source (1.0.0)
     minitest (5.16.3)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
     minitest-mock_expectations (1.1.3)
     mysql2 (0.5.3)
     parallel (1.19.1)
@@ -36,6 +42,12 @@ GEM
     phenix (1.0.1)
       activerecord (>= 4.2, < 7.1)
       bundler
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rainbow (3.0.0)
     rake (13.0.1)
     rexml (3.2.4)
@@ -62,11 +74,14 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
   minitest-mock_expectations (~> 1.1.3)
   mysql2 (>= 0.3.18, < 0.6.0)
   phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.2
+   2.4.4

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -23,11 +23,17 @@ GEM
     ast (2.4.0)
     bump (0.9.0)
     byebug (11.1.1)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    method_source (1.0.0)
     minitest (5.16.3)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
     minitest-mock_expectations (1.1.3)
     mysql2 (0.5.3)
     parallel (1.19.1)
@@ -36,6 +42,12 @@ GEM
     phenix (1.0.1)
       activerecord (>= 4.2, < 7.1)
       bundler
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rainbow (3.0.0)
     rake (13.0.1)
     rexml (3.2.4)
@@ -62,11 +74,14 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
   minitest-mock_expectations (~> 1.1.3)
   mysql2 (>= 0.4.4, < 0.6.0)
   phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.2
+   2.4.4

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -22,11 +22,17 @@ GEM
     ast (2.4.0)
     bump (0.9.0)
     byebug (11.1.1)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    method_source (1.0.0)
     minitest (5.16.3)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
     minitest-mock_expectations (1.1.3)
     mysql2 (0.5.3)
     parallel (1.19.1)
@@ -35,6 +41,12 @@ GEM
     phenix (1.0.1)
       activerecord (>= 4.2, < 7.1)
       bundler
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rainbow (3.0.0)
     rake (13.0.1)
     rexml (3.2.4)
@@ -62,11 +74,14 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
   minitest-mock_expectations (~> 1.1.3)
   mysql2 (>= 0.4.4)
   phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.2
+   2.4.4

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -22,11 +22,17 @@ GEM
     ast (2.4.2)
     bump (0.10.0)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    method_source (1.0.0)
     minitest (5.16.3)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
     minitest-mock_expectations (1.1.3)
     mysql2 (0.5.4)
     parallel (1.22.1)
@@ -35,6 +41,12 @@ GEM
     phenix (1.0.1)
       activerecord (>= 4.2, < 7.1)
       bundler
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     rainbow (3.1.1)
     rake (13.0.6)
     rexml (3.2.5)
@@ -61,11 +73,14 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
   minitest-mock_expectations (~> 1.1.3)
   mysql2 (~> 0.5)
   phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.2
+   2.4.4

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -21,11 +21,17 @@ GEM
     ast (2.4.2)
     bump (0.10.0)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    method_source (1.0.0)
     minitest (5.16.3)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
     minitest-mock_expectations (1.1.3)
     mysql2 (0.5.4)
     parallel (1.22.1)
@@ -34,6 +40,12 @@ GEM
     phenix (1.0.1)
       activerecord (>= 4.2, < 7.1)
       bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     rainbow (3.1.1)
     rake (13.0.6)
     rexml (3.2.5)
@@ -59,9 +71,12 @@ DEPENDENCIES
   bump
   byebug
   minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
   minitest-mock_expectations (~> 1.1.3)
   mysql2 (>= 0.4.4)
   phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'minitest/autorun'
+require 'pry-byebug'
 
 require 'active_record_host_pool'
 require 'logger'


### PR DESCRIPTION
I seem to always add `fail-fast`, `line`, and `pry-byebug` so it would be nice if they were always included. We need to use `pry-byebug ~> 3.9` until we drop Ruby 2.6.