### PR TITLE
Fix warning about ruby2_keywords usage

### DIFF
--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -33,11 +33,14 @@ module ActiveRecordHostPool
     end
 
     def self.ruby2_keywords(*); end unless respond_to?(:ruby2_keywords, true)
-    ruby2_keywords def execute_with_switching(*args, **kwargs)
+    # This one really does need ruby2_keywords; in Rails 6.0 the method does not take
+    # any keyword arguments, but in Rails 7.0 it does. So, we don't know whether or not
+    # what we're delegating to takes kwargs, so ruby2_keywords is needed.
+    ruby2_keywords def execute_with_switching(*args)
       if _host_pool_current_database && !_no_switch
         _switch_connection
       end
-      execute_without_switching(*args, **kwargs)
+      execute_without_switching(*args)
     end
 
     def drop_database_with_no_switching(*args)


### PR DESCRIPTION
/Users/ktsanaktsidis/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/active_record_host_pool-1.2.3/lib/active_record_host_pool/connection_adapter_mixin.rb:36: warning: Skipping set of ruby2_keywords flag for execute_with_switching (method accepts keywords or method does not accept argument splat)

When using ruby2_keywords, your method should not actually accept keywords itself. It's designed to be used on methods accepting *args only.