### PR TITLE
Release v1.2.4

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,11 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [1.2.4] - 2023-03-20
+### Fixed
+- Fixed the warning when using `ruby2_keywords` on `execute_with_switching`.
+- Simplified the `clear_query_caches_for_current_thread` patch.
+
 ## [1.2.3] - 2023-01-19
 ### Fixed
 - Fix the patch for `ActiveRecord::Base.clear_query_caches_for_current_thread` to work correctly right after the creation of a new connection pool. (https://github.com/zendesk/active_record_host_pool/pull/105)

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.3)
+    active_record_host_pool (1.2.4)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.3)
+    active_record_host_pool (1.2.4)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.3)
+    active_record_host_pool (1.2.4)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.3)
+    active_record_host_pool (1.2.4)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.3)
+    active_record_host_pool (1.2.4)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end


### PR DESCRIPTION
- Fixed the warning when using `ruby2_keywords` on `execute_with_switching`.
- Simplified the `clear_query_caches_for_current_thread` patch.