### PR TITLE
Remove Bump gem, move development dependencies to Gemfile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,6 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
-require 'bump/tasks'
 require 'rubocop/rake_task'
 
 # Pushing to rubygems is handled by a github workflow

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("activerecord", ">= 5.1.0", "< 7.1")
   s.add_runtime_dependency("mysql2")
 
-  s.add_development_dependency("bump")
   s.add_development_dependency("minitest", ">= 5.10.0")
   s.add_development_dependency("minitest-fail-fast")
   s.add_development_dependency("minitest-line")

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -30,13 +30,4 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("activerecord", ">= 5.1.0", "< 7.1")
   s.add_runtime_dependency("mysql2")
-
-  s.add_development_dependency("minitest", ">= 5.10.0")
-  s.add_development_dependency("minitest-fail-fast")
-  s.add_development_dependency("minitest-line")
-  s.add_development_dependency("minitest-mock_expectations", "~> 1.1.3")
-  s.add_development_dependency("phenix", ">= 1.0.1")
-  s.add_development_dependency("pry-byebug", "~> 3.9")
-  s.add_development_dependency("rake", '>= 12.0.0')
-  s.add_development_dependency('rubocop', '~> 0.80.0')
 end

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -1,3 +1,11 @@
 # frozen_string_literal: true
 
 gem "byebug", platform: :mri
+gem "minitest", ">= 5.10.0"
+gem "minitest-fail-fast"
+gem "minitest-line"
+gem "minitest-mock_expectations", "~> 1.1.3"
+gem "phenix", ">= 1.0.1"
+gem "pry-byebug", "~> 3.9"
+gem "rake", '>= 12.0.0'
+gem 'rubocop', '~> 0.80.0'

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -21,7 +21,6 @@ GEM
       tzinfo (~> 1.1)
     arel (8.0.0)
     ast (2.4.0)
-    bump (0.9.0)
     byebug (11.1.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
@@ -71,7 +70,6 @@ PLATFORMS
 DEPENDENCIES
   active_record_host_pool!
   activerecord (~> 5.1.6)
-  bump
   byebug
   minitest (>= 5.10.0)
   minitest-fail-fast

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -21,7 +21,6 @@ GEM
       tzinfo (~> 1.1)
     arel (9.0.0)
     ast (2.4.0)
-    bump (0.9.0)
     byebug (11.1.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
@@ -71,7 +70,6 @@ PLATFORMS
 DEPENDENCIES
   active_record_host_pool!
   activerecord (~> 5.2.0)
-  bump
   byebug
   minitest (>= 5.10.0)
   minitest-fail-fast

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -20,7 +20,6 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.0)
-    bump (0.9.0)
     byebug (11.1.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
@@ -71,7 +70,6 @@ PLATFORMS
 DEPENDENCIES
   active_record_host_pool!
   activerecord (~> 6.0.0)
-  bump
   byebug
   minitest (>= 5.10.0)
   minitest-fail-fast

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -20,7 +20,6 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ast (2.4.2)
-    bump (0.10.0)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -70,7 +69,6 @@ PLATFORMS
 DEPENDENCIES
   active_record_host_pool!
   activerecord (~> 6.1.0)
-  bump
   byebug
   minitest (>= 5.10.0)
   minitest-fail-fast

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -19,7 +19,6 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    bump (0.10.0)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -68,7 +67,6 @@ PLATFORMS
 DEPENDENCIES
   active_record_host_pool!
   activerecord (~> 7.0.0)
-  bump
   byebug
   minitest (>= 5.10.0)
   minitest-fail-fast


### PR DESCRIPTION
Removing `bump` seems simpler, imo, to modify the version file by hand, bundle, etc.

We've decided to move development dependencies from the gemspec to the (common) gemfile. Occasionally development dependencies (for one reason or another) need to be define in the common gemfile so having them in two places gets confusing.