### PR TITLE
Mutex in PoolProxy#disconnect!

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,9 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-- Drop Ruby 2.6.
+### Added
 - Start testing with Ruby 3.2.
+
+### Removed
+- Drop Ruby 2.6.
+
+### Fixed
+- Use a mutex inside `PoolProxy#disconnect!`. This might fix some `ActiveRecord::ConnectionNotEstablished` issues when a multi-threaded application is under heavy load. (Only applies when using Rails 6.1 or newer).
 
 ## [1.2.4] - 2023-03-20
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.2.5] - 2023-07-14
 ### Added
 - Start testing with Ruby 3.2.
 

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.4)
+    active_record_host_pool (1.2.5)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -82,4 +82,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.8
+   2.4.15

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.4)
+    active_record_host_pool (1.2.5)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -82,4 +82,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.8
+   2.4.15

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.4)
+    active_record_host_pool (1.2.5)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -82,4 +82,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.8
+   2.4.15

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.4)
+    active_record_host_pool (1.2.5)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -81,4 +81,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.8
+   2.4.15

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.4)
+    active_record_host_pool (1.2.5)
       activerecord (>= 5.1.0, < 7.1)
       mysql2
 
@@ -79,4 +79,4 @@ DEPENDENCIES
   rubocop (~> 0.80.0)
 
 BUNDLED WITH
-   2.4.8
+   2.4.15

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -74,7 +74,7 @@ module ActiveRecordHostPool
            @connection.object_id != @_cached_connection_object_id
          )
         log("select_db #{_host_pool_current_database}", "SQL") do
-          clear_cache! if respond_to?(:clear_cache!)
+          clear_cache!
           raw_connection.select_db(_host_pool_current_database)
         end
         @_cached_current_database = _host_pool_current_database

--- a/lib/active_record_host_pool/pool_proxy_6_1.rb
+++ b/lib/active_record_host_pool/pool_proxy_6_1.rb
@@ -3,6 +3,7 @@
 require 'delegate'
 require 'active_record'
 require 'active_record_host_pool/connection_adapter_mixin'
+require 'mutex_m'
 
 # this module sits in between ConnectionHandler and a bunch of different ConnectionPools (one per host).
 # when a connection is requested, it goes like:
@@ -15,6 +16,8 @@ require 'active_record_host_pool/connection_adapter_mixin'
 module ActiveRecordHostPool
   # Sits between ConnectionHandler and a bunch of different ConnectionPools (one per host).
   class PoolProxy < Delegator
+    include Mutex_m
+
     def initialize(pool_config)
       super(pool_config)
       @pool_config = pool_config
@@ -68,9 +71,11 @@ module ActiveRecordHostPool
       p = _connection_pool(false)
       return unless p
 
-      p.disconnect!
-      p.automatic_reconnect = true
-      _clear_connection_proxy_cache
+      synchronize do
+        p.disconnect!
+        p.automatic_reconnect = true
+        _clear_connection_proxy_cache
+      end
     end
 
     def automatic_reconnect=(value)

--- a/lib/active_record_host_pool/pool_proxy_6_1.rb
+++ b/lib/active_record_host_pool/pool_proxy_6_1.rb
@@ -69,7 +69,7 @@ module ActiveRecordHostPool
       return unless p
 
       p.disconnect!
-      p.automatic_reconnect = true if p.respond_to?(:automatic_reconnect=)
+      p.automatic_reconnect = true
       _clear_connection_proxy_cache
     end
 
@@ -77,7 +77,7 @@ module ActiveRecordHostPool
       p = _connection_pool(false)
       return unless p
 
-      p.automatic_reconnect = value if p.respond_to?(:automatic_reconnect=)
+      p.automatic_reconnect = value
     end
 
     def clear_reloadable_connections!

--- a/lib/active_record_host_pool/pool_proxy_legacy.rb
+++ b/lib/active_record_host_pool/pool_proxy_legacy.rb
@@ -71,7 +71,7 @@ module ActiveRecordHostPool
       return unless p
 
       p.disconnect!
-      p.automatic_reconnect = true if p.respond_to?(:automatic_reconnect=)
+      p.automatic_reconnect = true
       _clear_connection_proxy_cache
     end
 

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "1.2.4"
+  VERSION = "1.2.5"
 end


### PR DESCRIPTION
Rails added a mutex around their `ConnectionPool#disconnect!` in Rails 6.1. Perhaps we should do the same?

Also removes `respond_to?(:clear_cache!)` and `respond_to?(:automatic_reconnect=)` since those method have been around since at least Rails 4. Perhaps I should rather do this in a separate PR?