### PR TITLE
Remove change_db as the Trilogy database switching method

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,8 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
-- Remove `mysql2` as a direct dependency, test Rails 7.0 with `mysql2` and `activerecord-trilogy-adapter`
+- `Trilogy` is now a supported MySQL database adapter. ActiveRecordHostPool no longer requires `mysql2`, nor does it explicitly require `activerecord-trilogy-adapter`. Applications using ARHP will now need to explicitly require one of these adapters in its gemfile. When using `activerecord-trilogy-adapter` also ensure that the `trilogy` gem is locked to `v2.5.0+`.
+- Remove `mysql2` as a direct dependency, test Rails 7.0 with `mysql2` and `activerecord-trilogy-adapter`.
 
 ## [1.2.5] - 2023-07-14
 ### Added

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ test_pool_2 => 127.0.0.1/3306//root/false
 
 ## Support
 
-For now, the only backend known to work is MySQL, with the mysql2 or activerecord-trilogy-adapter gem.
+For now, the only backend known to work is MySQL, with the mysql2 or activerecord-trilogy-adapter gem. When using the activerecord-trilogy-adapter ensure that the transitive dependency Trilogy is v2.5.0+.
 Postgres, from an informal reading of the docs, will never support the concept of one server connection sharing multiple dbs.
 
 ## Installation

--- a/gemfiles/rails7.0_trilogy.gemfile
+++ b/gemfiles/rails7.0_trilogy.gemfile
@@ -6,5 +6,6 @@ gemspec path: '../'
 
 gem 'activerecord', '~> 7.0.0'
 gem 'activerecord-trilogy-adapter', '>= 3.0'
+gem 'trilogy', '>= 2.5.0'
 
 eval_gemfile 'common.rb'

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -60,7 +60,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.13.0)
-    trilogy (2.4.1)
+    trilogy (2.5.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.6.1)
@@ -81,6 +81,7 @@ DEPENDENCIES
   pry-byebug (~> 3.9)
   rake (>= 12.0.0)
   rubocop (~> 0.80.0)
+  trilogy (>= 2.5.0)
 
 BUNDLED WITH
    2.4.13

--- a/test/test_arhp_with_non_legacy_connection_handling.rb
+++ b/test/test_arhp_with_non_legacy_connection_handling.rb
@@ -56,7 +56,7 @@ if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
       # Assert that we switched, and only switched, in the order we expected.
       # If this assertion starts to fail, Rails is likely calling `#connection`
       # somewhere new, and we should investigate
-      db_switches = new_logger.string.scan(/(?:select_db|change_db) (\w+)/).flatten
+      db_switches = new_logger.string.scan(/select_db (\w+)/).flatten
       assert_equal ['arhp_test_db_shard_b', 'arhp_test_db_shard_c', 'arhp_test_db_shard_b'], db_switches
 
       new_logger.string = +''
@@ -83,7 +83,7 @@ if RAILS_6_1_WITH_NON_LEGACY_CONNECTION_HANDLING
 
       # If this assertion starts to fail, Rails is likely calling `#connection`
       # somewhere new, and we should investigate.
-      db_switches = new_logger.string.scan(/(?:select_db|change_db) (\w+)/).flatten
+      db_switches = new_logger.string.scan(/select_db (\w+)/).flatten
       assert_equal ['arhp_test_db_shard_c'], db_switches
 
       assert_equal [3, 1, 2], [records_on_shard_b, records_on_shard_c, records_on_shard_d]


### PR DESCRIPTION
Trilogy now has `select_db` as an alias for `change_db` which is the same method name that `mysql2` uses. Instead of conditionally determining the method name to use we can now just use the same method for both adapters.