### PR TITLE
bump version to 2.0.0.pre.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [2.0.0.pre.1]
+
 ### Added
 - Add support for Rails 7.1.
 - `Trilogy` is now a supported MySQL database adapter. ActiveRecordHostPool no longer requires `mysql2`, nor does it explicitly require `activerecord-trilogy-adapter`. Applications using ARHP will now need to explicitly require one of these adapters in its gemfile. When using `activerecord-trilogy-adapter` also ensure that the `trilogy` gem is locked to `v2.5.0+`.

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.5)
+    active_record_host_pool (2.0.0.pre.1)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.0_mysql2.gemfile.lock
+++ b/gemfiles/rails7.0_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.5)
+    active_record_host_pool (2.0.0.pre.1)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.5)
+    active_record_host_pool (2.0.0.pre.1)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.1_mysql2.gemfile.lock
+++ b/gemfiles/rails7.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.5)
+    active_record_host_pool (2.0.0.pre.1)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.1_trilogy.gemfile.lock
+++ b/gemfiles/rails7.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (1.2.5)
+    active_record_host_pool (2.0.0.pre.1)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "1.2.5"
+  VERSION = "2.0.0.pre.1"
 end


### PR DESCRIPTION
Releases changes from https://github.com/zendesk/active_record_host_pool/pull/122, https://github.com/zendesk/active_record_host_pool/pull/123, and https://github.com/zendesk/active_record_host_pool/pull/125.