### PR TITLE
fix list of files in gemspec

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,7 +6,7 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
-## [2.0.0.pre.1]
+## [2.0.0.pre.2]
 
 ### Added
 - Add support for Rails 7.1.

--- a/active_record_host_pool.gemspec
+++ b/active_record_host_pool.gemspec
@@ -11,17 +11,7 @@ Gem::Specification.new do |s|
     "MIT-LICENSE",
     "Readme.md"
   ]
-  s.files = [
-    "Readme.md",
-    "lib/active_record_host_pool.rb",
-    "lib/active_record_host_pool/clear_query_cache_patch.rb",
-    "lib/active_record_host_pool/connection_adapter_mixin.rb",
-    "lib/active_record_host_pool/connection_proxy.rb",
-    "lib/active_record_host_pool/pool_proxy.rb",
-    "lib/active_record_host_pool/pool_proxy_6_1.rb",
-    "lib/active_record_host_pool/pool_proxy_legacy.rb",
-    "lib/active_record_host_pool/version.rb"
-  ]
+  s.files = Dir.glob("lib/**/*") + %w[Readme.md Changelog.md]
   s.homepage = "https://github.com/zendesk/active_record_host_pool"
   s.license = "MIT"
 

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0.pre.1)
+    active_record_host_pool (2.0.0.pre.2)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.0_mysql2.gemfile.lock
+++ b/gemfiles/rails7.0_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0.pre.1)
+    active_record_host_pool (2.0.0.pre.2)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0.pre.1)
+    active_record_host_pool (2.0.0.pre.2)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.1_mysql2.gemfile.lock
+++ b/gemfiles/rails7.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0.pre.1)
+    active_record_host_pool (2.0.0.pre.2)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.1_trilogy.gemfile.lock
+++ b/gemfiles/rails7.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0.pre.1)
+    active_record_host_pool (2.0.0.pre.2)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "2.0.0.pre.1"
+  VERSION = "2.0.0.pre.2"
 end


### PR DESCRIPTION
Replace static list of files (which had to be updated manually and sometimes wasn’t, which broke the release process) with all `lib` files + docs.
