### PR TITLE
Implement equality for connection proxies to consider database

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Fixed
+- Implement equality for connection proxies to consider database; allows fixture loading for different databases
+
 ## [2.0.0.pre.2]
 
 ### Added

--- a/lib/active_record_host_pool/connection_proxy.rb
+++ b/lib/active_record_host_pool/connection_proxy.rb
@@ -6,6 +6,7 @@ require "delegate"
 # for each call to the connection.  upon executing a statement, the connection will switch to that database.
 module ActiveRecordHostPool
   class ConnectionProxy < Delegator
+    attr_reader :database
     def initialize(cx, database)
       super(cx)
       @cx = cx
@@ -51,6 +52,18 @@ module ActiveRecordHostPool
       end
     end
     ruby2_keywords :send if respond_to?(:ruby2_keywords, true)
+
+    def ==(other)
+      self.class == other.class &&
+        other.respond_to?(:unproxied) && @cx == other.unproxied &&
+        other.respond_to?(:database) && @database == other.database
+    end
+
+    alias_method :eql?, :==
+
+    def hash
+      [self.class, @cx, @database].hash
+    end
 
     private
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -65,6 +65,11 @@ module ARHPTestSetup
           establish_connection(:test_pool_1_db_a)
         end
 
+        class Pool1DbAOther < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_1_db_a)
+        end
+
         class Pool1DbAReplica < ActiveRecord::Base
           self.table_name = "tests"
           establish_connection(:test_pool_1_db_a_replica)
@@ -109,6 +114,10 @@ module ARHPTestSetup
         end
 
         class Pool1DbA < AbstractPool1DbA
+          self.table_name = "tests"
+        end
+
+        class Pool1DbAOther < AbstractPool1DbA
           self.table_name = "tests"
         end
 

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -86,6 +86,20 @@ class ActiveRecordHostPoolTest < Minitest::Test
     assert_equal true, Pool1DbA.connection.send(:test_private_method)
   end
 
+  def test_connection_proxy_equality
+    # Refer to same underlying connection and same database
+    assert_same Pool1DbA.connection.raw_connection, Pool1DbAOther.connection.raw_connection
+    assert Pool1DbA.connection == Pool1DbAOther.connection
+    assert Pool1DbA.connection.eql?(Pool1DbAOther.connection)
+    assert_equal Pool1DbA.connection.hash, Pool1DbAOther.connection.hash
+
+    # Refer to same underlying connection but with a different database
+    assert_same Pool1DbA.connection.raw_connection, Pool1DbB.connection.raw_connection
+    refute Pool1DbA.connection == Pool1DbB.connection
+    refute Pool1DbA.connection.eql?(Pool1DbB.connection)
+    refute_equal Pool1DbA.connection.hash, Pool1DbB.connection.hash
+  end
+
   def test_object_creation
     Pool1DbA.create(val: "foo")
     assert_equal("arhp_test_db_a", current_database(Pool1DbA))

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -137,16 +137,16 @@ class ThreadSafetyTest < Minitest::Test
 
     sleep 0.01 until threads.all? { |t| t[:done] }
 
-    # Each thread only saw one connection
-    threads_to_connections.each do |_thread, connections|
-      assert_equal(1, connections.uniq.length)
+    # Each thread saw two connections (one for each database)
+    threads_to_connections.each_value do |connections|
+      assert_equal(2, connections.uniq.length)
       assert_equal(1, connections.map(&:unproxied).uniq.length)
     end
 
-    # Each thread's connection was unique
+    # Connections were unique to a thread
     connections = threads_to_connections.values.flatten
-    assert_equal(3, connections.uniq.length)
-    assert_equal(3, connections.map(&:unproxied).uniq.length)
+    assert_equal(6, connections.uniq.length) # 3 threads at 2 connections per thread
+    assert_equal(3, connections.map(&:unproxied).uniq.length) # 1 unique underlying connection per thread
 
     threads.each(&:wakeup)
     threads.each(&:join)


### PR DESCRIPTION
Currently two `ConnectionProxy`s are considered the same hash key if they use the same underlying connection but a _different_ database. This breaks fixture loading [here](https://github.com/rails/rails/blob/v6.1.7.6/activerecord/lib/active_record/fixtures.rb#L621-L627) because all fixture sets get inserted using the same `ConnectionProxy` (and thus the same db).

Even though I'm really concerned with the behavior when used as a hash key, I think it makes sense to also implement `==` ...  two different proxies with same connection/db will ultimately execute queries on the same connection with the same db selected. Also the docs suggest aliasing `eql?` to `==` is standard practice.

Because `class` [delegates](https://github.com/zendesk/active_record_host_pool/blob/main/lib/active_record_host_pool/connection_proxy.rb#L28-L31) to the connection, `self.class == other.class` could be true if `other` was a `ConnectionProxy` or a `Mysql2Adapter`, and so I check that it responds to `unproxied` and `database` to ensure it's actually a `ConnectionProxy` ... maybe overkill