### PR TITLE
Switch from aliasing to prepend

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- ActiveRecordHostPool now uses prepend to patch `#execute`, `#raw_execute`, `#drop_database`, `#create_database`, and `#disconnect!`. Prepending is incompatible when also using `alias` or `alias_method` to patch those methods; avoid aliasing them to prevent an infinite loop.
+
 ### Removed
 - Dropped support for Ruby 2.7.x.
 

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -18,32 +18,7 @@ end
 
 module ActiveRecordHostPool
   module DatabaseSwitch
-    def self.included(base)
-      base.class_eval do
-        attr_reader(:_host_pool_current_database)
-
-        # Patch `raw_execute` instead of `execute` since this commit:
-        # https://github.com/rails/rails/commit/f69bbcbc0752ca5d5af327d55922614a26f5c7e9
-        case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
-        when "7.1"
-          alias_method :raw_execute_without_switching, :raw_execute
-          alias_method :raw_execute, :raw_execute_with_switching
-        else
-          alias_method :execute_without_switching, :execute
-          alias_method :execute, :execute_with_switching
-        end
-
-        alias_method :drop_database_without_no_switching, :drop_database
-        alias_method :drop_database, :drop_database_with_no_switching
-
-        alias_method :create_database_without_no_switching, :create_database
-        alias_method :create_database, :create_database_with_no_switching
-
-        alias_method :disconnect_without_host_pooling!, :disconnect!
-        alias_method :disconnect!, :disconnect_with_host_pooling!
-      end
-    end
-
+    attr_reader :_host_pool_current_database
     def initialize(*)
       @_cached_current_database = nil
       super
@@ -55,39 +30,41 @@ module ActiveRecordHostPool
     end
 
     if ActiveRecord.version >= Gem::Version.new("7.1")
-      def raw_execute_with_switching(...)
+      # Patch `raw_execute` instead of `execute` since this commit:
+      # https://github.com/rails/rails/commit/f69bbcbc0752ca5d5af327d55922614a26f5c7e9
+      def raw_execute(...)
         if _host_pool_current_database && !_no_switch
           _switch_connection
         end
-        raw_execute_without_switching(...)
+        super
       end
     else
-      def execute_with_switching(...)
+      def execute(...)
         if _host_pool_current_database && !_no_switch
           _switch_connection
         end
-        execute_without_switching(...)
+        super
       end
     end
 
-    def drop_database_with_no_switching(...)
+    def drop_database(...)
       self._no_switch = true
-      drop_database_without_no_switching(...)
+      super
     ensure
       self._no_switch = false
     end
 
-    def create_database_with_no_switching(...)
+    def create_database(...)
       self._no_switch = true
-      create_database_without_no_switching(...)
+      super
     ensure
       self._no_switch = false
     end
 
-    def disconnect_with_host_pooling!
+    def disconnect!
       @_cached_current_database = nil
       @_cached_connection_object_id = nil
-      disconnect_without_host_pooling!
+      super
     end
 
     private
@@ -126,9 +103,9 @@ end
 
 case ActiveRecordHostPool.loaded_db_adapter
 when :mysql2
-  ActiveRecord::ConnectionAdapters::Mysql2Adapter.include(ActiveRecordHostPool::DatabaseSwitch)
+  ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend(ActiveRecordHostPool::DatabaseSwitch)
 when :trilogy
-  ActiveRecord::ConnectionAdapters::TrilogyAdapter.include(ActiveRecordHostPool::DatabaseSwitch)
+  ActiveRecord::ConnectionAdapters::TrilogyAdapter.prepend(ActiveRecordHostPool::DatabaseSwitch)
 end
 
 ActiveRecord::ConnectionAdapters::PoolConfig.prepend(ActiveRecordHostPool::PoolConfigPatch)

--- a/test/database.yml
+++ b/test/database.yml
@@ -36,7 +36,6 @@ test_pool_1_db_a:
   username: <%= mysql.user %>
   password: "<%= mysql.password %>"
   host: <%= mysql.host %>
-  reconnect: true
 
 # Mimic configurations as read by active_record_shards/ar_flexmaster
 test_pool_1_db_a_replica:
@@ -46,7 +45,6 @@ test_pool_1_db_a_replica:
   username: <%= mysql.user %>
   password: "<%= mysql.password %>"
   host: <%= mysql.host %>
-  reconnect: true
   slave: true
 
 test_pool_1_db_b:
@@ -56,7 +54,6 @@ test_pool_1_db_b:
   username: <%= mysql.user %>
   password: "<%= mysql.password %>"
   host: <%= mysql.host %>
-  reconnect: true
 
 test_pool_1_db_not_there:
   adapter: <%= adapter %>
@@ -65,7 +62,6 @@ test_pool_1_db_not_there:
   username: <%= mysql.user %>
   password: "<%= mysql.password %>"
   host: <%= mysql.host %>
-  reconnect: true
 
 test_pool_2_db_d:
   adapter: <%= adapter %>
@@ -75,7 +71,6 @@ test_pool_2_db_d:
   password: "<%= mysql.password %>"
   host: <%= mysql.host %>
   port: <%= mysql.port %>
-  reconnect: true
 
 test_pool_2_db_e:
   adapter: <%= adapter %>
@@ -85,7 +80,6 @@ test_pool_2_db_e:
   password: "<%= mysql.password %>"
   host: <%= mysql.host %>
   port: <%= mysql.port %>
-  reconnect: true
 
 test_pool_3_db_e:
   adapter: <%= adapter %>
@@ -95,7 +89,6 @@ test_pool_3_db_e:
   password:
   host: <%= mysql.host %>
   port: <%= mysql.port %>
-  reconnect: true
 
 # test_pool_1_db_c needs to be the last database defined in the file
 # otherwise the test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
@@ -107,4 +100,3 @@ test_pool_1_db_c:
   username: <%= mysql.user %>
   password: "<%= mysql.password %>"
   host: <%= mysql.host %>
-  reconnect: true

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -186,6 +186,8 @@ class ActiveRecordHostPoolTest < Minitest::Test
       Pool2DbD.connection.execute("KILL #{thread_id}")
     end
 
+    switch_to_klass.connection.reconnect!
+
     # and finally, did mysql reconnect correctly?
     puts "\nAnd now we end up on #{current_database(switch_to_klass)}" if debug_me
     assert_equal expected_database, current_database(switch_to_klass)

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -132,7 +132,7 @@ class ActiveRecordHostPoolTest < Minitest::Test
 
   def test_no_switch_when_creating_db
     conn = Pool1DbA.connection
-    meth = (ActiveRecord.version >= Gem::Version.new("7.1")) ? :raw_execute_without_switching : :execute_without_switching
+    meth = (ActiveRecord.version >= Gem::Version.new("7.1")) ? :raw_execute : :execute
     assert_called(conn, meth) do
       refute_called(conn, :_switch_connection) do
         assert conn._host_pool_current_database
@@ -143,7 +143,7 @@ class ActiveRecordHostPoolTest < Minitest::Test
 
   def test_no_switch_when_dropping_db
     conn = Pool1DbA.connection
-    meth = (ActiveRecord.version >= Gem::Version.new("7.1")) ? :raw_execute_without_switching : :execute_without_switching
+    meth = (ActiveRecord.version >= Gem::Version.new("7.1")) ? :raw_execute : :execute
     assert_called(conn, meth) do
       refute_called(conn, :_switch_connection) do
         assert conn._host_pool_current_database

--- a/test/three_tier_database.yml
+++ b/test/three_tier_database.yml
@@ -43,7 +43,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
 
   # Mimic configurations as read by active_record_shards/ar_flexmaster
   test_pool_1_db_a_replica:
@@ -53,7 +52,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
     replica: true
 
   test_pool_1_db_b:
@@ -63,7 +61,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
 
   test_pool_1_db_c:
     adapter: <%= adapter %>
@@ -72,7 +69,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
 
   test_pool_1_db_not_there:
     adapter: <%= adapter %>
@@ -81,7 +77,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
 
   test_pool_1_db_shard_a:
     adapter: <%= adapter %>
@@ -90,7 +85,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
 
   test_pool_1_db_shard_b:
     adapter: <%= adapter %>
@@ -99,7 +93,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
 
   test_pool_1_db_shard_b_replica:
     adapter: <%= adapter %>
@@ -108,7 +101,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
     replica: true
 
   test_pool_1_db_shard_c:
@@ -118,7 +110,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
 
   test_pool_1_db_shard_c_replica:
     adapter: <%= adapter %>
@@ -127,7 +118,6 @@ test:
     username: <%= mysql.user %>
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
-    reconnect: true
     replica: true
 
   test_pool_2_db_shard_d:
@@ -138,7 +128,6 @@ test:
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
     port: <%= mysql.port %>
-    reconnect: true
 
   test_pool_2_db_shard_d_replica:
     adapter: <%= adapter %>
@@ -148,7 +137,6 @@ test:
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
     port: <%= mysql.port %>
-    reconnect: true
     replica: true
 
   test_pool_2_db_d:
@@ -159,7 +147,6 @@ test:
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
     port: <%= mysql.port %>
-    reconnect: true
 
   test_pool_2_db_e:
     adapter: <%= adapter %>
@@ -169,7 +156,6 @@ test:
     password: "<%= mysql.password %>"
     host: <%= mysql.host %>
     port: <%= mysql.port %>
-    reconnect: true
 
   test_pool_3_db_e:
     adapter: <%= adapter %>
@@ -179,4 +165,3 @@ test:
     password:
     host: <%= mysql.host %>
     port: <%= mysql.port %>
-    reconnect: true


### PR DESCRIPTION
`alias_method` used to be the way to patch methods in Ruby. The more modern, and elegant (imo), way is to use prepend.

## NOTE WHEN UPGRADING

ActiveRecordHostPool now uses prepend to patch `#execute`, `#raw_execute`, `#drop_database`, `#create_database`, and `#disconnect!`. Prepending is incompatible when also using `alias` or `alias_method` to patch those methods; avoid aliasing them to prevent an infinite loop.

Prepending **AND** aliasing is dangerous, if you prepend a method and later use alias to patch the same method you end up in an infinite loop:

```ruby
module GreetPatch
  def greet
    puts 'Hello'
    super
  end
end

class Foo
  class << self
    def greet
      puts 'Hi'
    end
  end
end

Foo.singleton_class.prepend GreetPatch # Prepend greet.

Foo.singleton_class.class_eval do
  def new_greet
    puts 'Greetings'
    original_greet
  end
  alias :original_greet :greet # Patch greet with alias.
  alias :greet :new_greet
end

Foo.greet # Raises stack level too deep.
```

We don't get the infinite loop if we prepend _after_ aliasing:

```ruby
module GreetPatch
  def greet
    puts 'Hello'
    super
  end
end

class Foo
  class << self
    def greet
      puts 'Hi'
    end
  end
end

Foo.singleton_class.class_eval do
  def new_greet
    puts 'Greetings'
    original_greet
  end
  alias :original_greet :greet
  alias :greet :new_greet
end

Foo.singleton_class.prepend GreetPatch

Foo.greet =>
Hello
Greetings
Hi
```