### PR TITLE
Release v2.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.0]
+
 ### Changed
 - ActiveRecordHostPool now uses prepend to patch `#execute`, `#raw_execute`, `#drop_database`, `#create_database`, and `#disconnect!`. Prepending is incompatible when also using `alias` or `alias_method` to patch those methods; avoid aliasing them to prevent an infinite loop.
 

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0)
+    active_record_host_pool (2.1.0)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.0_mysql2.gemfile.lock
+++ b/gemfiles/rails7.0_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0)
+    active_record_host_pool (2.1.0)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0)
+    active_record_host_pool (2.1.0)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.1_mysql2.gemfile.lock
+++ b/gemfiles/rails7.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0)
+    active_record_host_pool (2.1.0)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/gemfiles/rails7.1_trilogy.gemfile.lock
+++ b/gemfiles/rails7.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.0.0)
+    active_record_host_pool (2.1.0)
       activerecord (>= 6.1.0, < 7.2)
 
 GEM

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
- Switch from usage of alias_method to use prepend.
- Drops support for Ruby < 3.0.