### PR TITLE
Create a separate pool for sharded connections

### DIFF
--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -133,7 +133,8 @@ module ActiveRecordHostPool
 
     def _pool_key
       @_pool_key ||= "#{@config[:host]}/#{@config[:port]}/#{@config[:socket]}/" \
-                     "#{@config[:username]}/#{replica_configuration? && "replica"}"
+        "#{@config[:username]}/#{replica_configuration? && "replica"}/" \
+        "#{shard_config? && "shard"}"
     end
 
     def _connection_pool(auto_create = true)
@@ -180,6 +181,11 @@ module ActiveRecordHostPool
 
     def replica_configuration?
       @config[:replica] || @config[:slave]
+    end
+
+    # This used to have separate pools in dev/test env to avoid problems when we tried to query sharded tables after querying the non-shared DB.
+    def shard_config?
+      @config[:database].include? "shard"
     end
   end
 end

--- a/test/database.yml
+++ b/test/database.yml
@@ -3,9 +3,9 @@
 
 # ARHP creates separate connection pools based on the pool key.
 # The pool key is defined as:
-#   host / port / socket / username / replica
+#   host / port / socket / username / replica / shard
 #
-# Therefore two databases with identical host, port, socket, username, and replica status will share a connection pool.
+# Therefore two databases with identical host, port, socket, username, replica status and shard status (based on the DB name) will share a connection pool.
 # If any part (host, port, etc.) of the pool key differ, two databases will _not_ share a connection pool.
 #
 # Below, "test_pool_1..." and "test_pool_2..." have identical host, username, socket, and replica status but the port information differs.
@@ -19,6 +19,7 @@
 # | socket   |                |                |
 # | username | root           | root           |
 # | replica  | false          | false          |
+# | shard    | shard           |               |
 # |----------+----------------+----------------|
 #
 # Note: The configuration items must be explicitly defined or will be blank in the pool key.
@@ -26,8 +27,8 @@
 #       e.g. "test_pool_1" will default to port 3306 but because it is not explicitly defined it will not share a pool with test_pool_2
 #
 #       ARHP will therefore create the following pool keys:
-#       test_pool_1 => 127.0.0.1///root/false
-#       test_pool_2 => 127.0.0.1/3306//root/false
+#       test_pool_1 => 127.0.0.1///root/false/true
+#       test_pool_2 => 127.0.0.1/3306//root/false/false
 
 test_pool_1_db_a:
   adapter: <%= adapter %>
@@ -89,6 +90,14 @@ test_pool_3_db_e:
   password:
   host: <%= mysql.host %>
   port: <%= mysql.port %>
+
+test_pool_1_db_shard:
+  adapter: <%= adapter %>
+  encoding: utf8
+  database: arhp_test_db_shard
+  username: <%= mysql.user %>
+  password: "<%= mysql.password %>"
+  host: <%= mysql.host %>
 
 # test_pool_1_db_c needs to be the last database defined in the file
 # otherwise the test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -94,6 +94,11 @@ module ARHPTestSetup
           self.table_name = "tests"
           establish_connection(:test_pool_3_db_e)
         end
+        
+        class Pool1DbShard < ActiveRecord::Base
+          self.table_name = "tests"
+          establish_connection(:test_pool_1_db_shard)
+        end
       RUBY
     else
       eval(<<-RUBY, binding, __FILE__, __LINE__ + 1)

--- a/test/test_arhp_legacy_connection_handling_only_tests.rb
+++ b/test/test_arhp_legacy_connection_handling_only_tests.rb
@@ -24,5 +24,9 @@ if LEGACY_CONNECTION_HANDLING
       simulate_rails_app_active_record_railties
       assert_equal(Pool1DbA.connection.raw_connection, Pool1DbC.connection.raw_connection)
     end
+
+    def test_shards_and_non_shards_should_not_share_a_connection
+      refute_equal(Pool1DbA.connection.raw_connection, Pool1DbShard.connection.raw_connection)
+    end
   end
 end

--- a/test/three_tier_database.yml
+++ b/test/three_tier_database.yml
@@ -5,7 +5,7 @@
 #
 # ARHP creates separate connection pools based on the pool key.
 # The pool key is defined as:
-#   host / port / socket / username / replica
+#   host / port / socket / username / replica / shard
 #
 # Therefore two databases with identical host, port, socket, username, and replica status will share a connection pool.
 # If any part (host, port, etc.) of the pool key differ, two databases will _not_ share a connection pool.
@@ -26,6 +26,7 @@
 # | socket   |                |                |
 # | username | root           | root           |
 # | replica  | false          | false          |
+# | shard    | shard          |               |
 #
 # The configuration items must be explicitly defined or they will be blank in the pool key.
 # Configurations with matching _implicit_ items but differing _explicit_ items will create separate pools.


### PR DESCRIPTION
When we switch between sharded (using https://github.com/zendesk/active_record_shards) and non-sharded tables within ActiveRecord-related logic (for example, checking an Arturo flag within a serializer), the next request may go to the non-sharded database (select_db is skipped). To work around this, the connection pool logic has been extended to make separate pools for sharded databases. 

cc @HeyNonster 