### PR TITLE
Remove `ForkTracker.check!` for Rails > 7.1, fix Rails main testing.

### DIFF
--- a/.github/workflows/test_against_rails_main.yml
+++ b/.github/workflows/test_against_rails_main.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  push:
   schedule:
     - cron: "0 0 * * *" # Run every day at 00:00 UTC
   workflow_dispatch:

--- a/lib/active_record_host_pool/clear_query_cache_patch.rb
+++ b/lib/active_record_host_pool/clear_query_cache_patch.rb
@@ -17,7 +17,7 @@
 # This is a private Rails API and may change in future releases as they're
 # actively working on sharding in Rails 6 and above.
 module ActiveRecordHostPool
-  # For Rails 7.1.
+  # For Rails 7.1+
   module ClearQueryCachePatch
     def clear_query_caches_for_current_thread
       connection_handler.each_connection_pool do |pool|
@@ -37,9 +37,9 @@ module ActiveRecordHostPool
 end
 
 case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
-when "7.1"
-  # Fix https://github.com/rails/rails/commit/401e2f24161ed6047ae33c322aaf6584b7728ab9
-  ActiveRecord::Base.singleton_class.prepend(ActiveRecordHostPool::ClearQueryCachePatch)
 when "6.1", "7.0"
   ActiveRecord::Base.singleton_class.prepend(ActiveRecordHostPool::ClearOnHandlerPatch)
+else
+  # Fix https://github.com/rails/rails/commit/401e2f24161ed6047ae33c322aaf6584b7728ab9
+  ActiveRecord::Base.singleton_class.prepend(ActiveRecordHostPool::ClearQueryCachePatch)
 end

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -8,10 +8,8 @@ when :trilogy
   when "6.1", "7.0"
     require "trilogy_adapter/connection"
     ActiveRecord::Base.extend(TrilogyAdapter::Connection)
-  when "7.1"
-    require "active_record/connection_adapters/trilogy_adapter"
   else
-    raise "Unsupported version of Rails (v#{ActiveRecord::VERSION::STRING})"
+    require "active_record/connection_adapters/trilogy_adapter"
   end
 end
 

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -93,8 +93,6 @@ module ActiveRecordHostPool
 
   module PoolConfigPatch
     def pool
-      ActiveSupport::ForkTracker.check!
-
       @pool || synchronize { @pool ||= ActiveRecordHostPool::PoolProxy.new(self) }
     end
   end


### PR DESCRIPTION
This was removed in Rails[^1]. In the PR byroot notes that requiring
Ruby 3.1+ (like we do in ARHP) allows for removing `ForkTracker.check!`
entirely but I'm not positive of the implications so I'm not removing
for versions of Rails <= 7.1.

Also, fixes Rails main.

[^1]:(https://github.com/rails/rails/pull/50670)