### PR TITLE
Release v2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ pkg/*
 .bundle
 *.log
 localgems
-Gemfile.lock
 tmp

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [2.2.0]
 ### Removed
 - Support for Ruby 3.0.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,108 @@
+PATH
+  remote: .
+  specs:
+    active_record_host_pool (2.1.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (6.1.7.6)
+      activesupport (= 6.1.7.6)
+    activerecord (6.1.7.6)
+      activemodel (= 6.1.7.6)
+      activesupport (= 6.1.7.6)
+    activesupport (6.1.7.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.3)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    json (2.7.1)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    method_source (1.0.0)
+    minitest (5.16.3)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.1.3)
+    mysql2 (0.5.5)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.1.0)
+      activerecord (>= 4.2, < 7.1)
+      bundler
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
+    racc (1.7.3)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rubocop (1.59.0)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.4)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.30.0)
+      parser (>= 3.2.1.0)
+    rubocop-performance (1.20.2)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.33.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.59.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.3)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.3.1)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.20.2)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+    zeitwerk (2.6.12)
+
+PLATFORMS
+  arm64-darwin-21
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 6.1.0)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  mysql2 (~> 0.5)
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+
+BUNDLED WITH
+   2.4.13

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_record_host_pool (2.1.0)
+    active_record_host_pool (2.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails6.1_mysql2.gemfile.lock
+++ b/gemfiles/rails6.1_mysql2.gemfile.lock
@@ -1,0 +1,109 @@
+PATH
+  remote: ..
+  specs:
+    active_record_host_pool (2.1.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (6.1.7.8)
+      activesupport (= 6.1.7.8)
+    activerecord (6.1.7.8)
+      activemodel (= 6.1.7.8)
+      activesupport (= 6.1.7.8)
+    activesupport (6.1.7.8)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.3)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    minitest (5.24.1)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.2.0)
+    mysql2 (0.5.6)
+    parallel (1.25.1)
+    parser (3.3.4.0)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.3.0)
+      activerecord (>= 6.1)
+      bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.2)
+      strscan
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.39.2)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.64.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+    zeitwerk (2.6.16)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 6.1.0)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  mysql2 (~> 0.5)
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+
+BUNDLED WITH
+   2.5.14

--- a/gemfiles/rails6.1_mysql2.gemfile.lock
+++ b/gemfiles/rails6.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.1.0)
+    active_record_host_pool (2.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails6.1_trilogy.gemfile.lock
+++ b/gemfiles/rails6.1_trilogy.gemfile.lock
@@ -1,0 +1,113 @@
+PATH
+  remote: ..
+  specs:
+    active_record_host_pool (2.1.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (6.1.7.8)
+      activesupport (= 6.1.7.8)
+    activerecord (6.1.7.8)
+      activemodel (= 6.1.7.8)
+      activesupport (= 6.1.7.8)
+    activerecord-trilogy-adapter (3.1.2)
+      activerecord (>= 6.0.a, < 7.1.a)
+      trilogy (>= 2.4.0)
+    activesupport (6.1.7.8)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.3)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    minitest (5.24.1)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.2.0)
+    parallel (1.25.1)
+    parser (3.3.4.0)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.3.0)
+      activerecord (>= 6.1)
+      bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.2)
+      strscan
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.39.2)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.64.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    trilogy (2.8.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+    zeitwerk (2.6.16)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 6.1.0)
+  activerecord-trilogy-adapter (>= 3.1)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+  trilogy (>= 2.5.0)
+
+BUNDLED WITH
+   2.5.14

--- a/gemfiles/rails6.1_trilogy.gemfile.lock
+++ b/gemfiles/rails6.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.1.0)
+    active_record_host_pool (2.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.0_mysql2.gemfile.lock
+++ b/gemfiles/rails7.0_mysql2.gemfile.lock
@@ -1,0 +1,107 @@
+PATH
+  remote: ..
+  specs:
+    active_record_host_pool (2.1.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.0.8.4)
+      activesupport (= 7.0.8.4)
+    activerecord (7.0.8.4)
+      activemodel (= 7.0.8.4)
+      activesupport (= 7.0.8.4)
+    activesupport (7.0.8.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.3)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    minitest (5.24.1)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.2.0)
+    mysql2 (0.5.6)
+    parallel (1.25.1)
+    parser (3.3.4.0)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.3.0)
+      activerecord (>= 6.1)
+      bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.2)
+      strscan
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.39.2)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.64.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 7.0.0)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  mysql2 (~> 0.5)
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+
+BUNDLED WITH
+   2.5.14

--- a/gemfiles/rails7.0_mysql2.gemfile.lock
+++ b/gemfiles/rails7.0_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.1.0)
+    active_record_host_pool (2.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -1,0 +1,111 @@
+PATH
+  remote: ..
+  specs:
+    active_record_host_pool (2.1.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.0.8.4)
+      activesupport (= 7.0.8.4)
+    activerecord (7.0.8.4)
+      activemodel (= 7.0.8.4)
+      activesupport (= 7.0.8.4)
+    activerecord-trilogy-adapter (3.1.2)
+      activerecord (>= 6.0.a, < 7.1.a)
+      trilogy (>= 2.4.0)
+    activesupport (7.0.8.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.3)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    minitest (5.24.1)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.2.0)
+    parallel (1.25.1)
+    parser (3.3.4.0)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.3.0)
+      activerecord (>= 6.1)
+      bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.2)
+      strscan
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.39.2)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.64.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    trilogy (2.8.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 7.0.0)
+  activerecord-trilogy-adapter (>= 3.1)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+  trilogy (>= 2.5.0)
+
+BUNDLED WITH
+   2.5.14

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.1.0)
+    active_record_host_pool (2.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.1_mysql2.gemfile.lock
+++ b/gemfiles/rails7.1_mysql2.gemfile.lock
@@ -1,0 +1,119 @@
+PATH
+  remote: ..
+  specs:
+    active_record_host_pool (2.1.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.1.3.2)
+      activesupport (= 7.1.3.2)
+    activerecord (7.1.3.2)
+      activemodel (= 7.1.3.2)
+      activesupport (= 7.1.3.2)
+      timeout (>= 0.4.0)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.1)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    minitest (5.23.1)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.2.0)
+    mutex_m (0.2.0)
+    mysql2 (0.5.6)
+    parallel (1.24.0)
+    parser (3.3.2.0)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.3.0)
+      activerecord (>= 6.1)
+      bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
+    rubocop (1.63.5)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.0)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.36.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.63.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    timeout (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 7.1.0)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  mysql2 (~> 0.5)
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+
+BUNDLED WITH
+   2.5.6

--- a/gemfiles/rails7.1_mysql2.gemfile.lock
+++ b/gemfiles/rails7.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.1.0)
+    active_record_host_pool (2.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.1_trilogy.gemfile.lock
+++ b/gemfiles/rails7.1_trilogy.gemfile.lock
@@ -1,0 +1,119 @@
+PATH
+  remote: ..
+  specs:
+    active_record_host_pool (2.1.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.1.3.4)
+      activesupport (= 7.1.3.4)
+    activerecord (7.1.3.4)
+      activemodel (= 7.1.3.4)
+      activesupport (= 7.1.3.4)
+      timeout (>= 0.4.0)
+    activesupport (7.1.3.4)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    method_source (1.1.0)
+    minitest (5.24.1)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.2.0)
+    mutex_m (0.2.0)
+    parallel (1.25.1)
+    parser (3.3.4.0)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.3.0)
+      activerecord (>= 6.1)
+      bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.0)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.2)
+      strscan
+    rubocop (1.64.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.3)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    standard (1.39.2)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.64.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    timeout (0.4.1)
+    trilogy (2.8.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 7.1.0)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+  trilogy (>= 2.5.0)
+
+BUNDLED WITH
+   2.5.14

--- a/gemfiles/rails7.1_trilogy.gemfile.lock
+++ b/gemfiles/rails7.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (2.1.0)
+    active_record_host_pool (2.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
### Removed
- Support for Ruby 3.0.

### Added
- Rails 6.1 testing with Trilogy.

### Fixed
- Fixed using ActiveRecordHostPool and the `activerecord-trilogy-adapter v3.1+`.

### Changed
-  ActiveRecordHostPool will now raise an exception if you try to use a version of `activerecord-trilogy-adapter < 3.1`.