### PR TITLE
Add support for Rails 7.2 & Rails main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
           - rails7.0_trilogy
           - rails7.1_mysql2
           - rails7.1_trilogy
+          - rails7.2_mysql2
+          - rails7.2_trilogy
+        include:
+          - {ruby-version: "3.3", gemfile: "rails_main_mysql2"}
+          - {ruby-version: "3.3", gemfile: "rails_main_trilogy"}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Added
+- Support and testing for Rails 7.2 & Rails main.
+
 ### Removed
 - Support for ActiveRecord's legacy connection handling.
 

--- a/gemfiles/rails7.2_mysql2.gemfile
+++ b/gemfiles/rails7.2_mysql2.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: "../"
+
+gem "activerecord", "~> 7.2.0"
+gem "mysql2", "~> 0.5"
+
+eval_gemfile "common.rb"

--- a/gemfiles/rails7.2_mysql2.gemfile.lock
+++ b/gemfiles/rails7.2_mysql2.gemfile.lock
@@ -1,0 +1,121 @@
+PATH
+  remote: ..
+  specs:
+    active_record_host_pool (2.2.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.2.1)
+      activesupport (= 7.2.1)
+    activerecord (7.2.1)
+      activemodel (= 7.2.1)
+      activesupport (= 7.2.1)
+      timeout (>= 0.4.0)
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    logger (1.6.0)
+    method_source (1.1.0)
+    minitest (5.25.1)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.2.0)
+    mysql2 (0.5.6)
+    parallel (1.26.3)
+    parser (3.3.4.2)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.4.0)
+      activerecord (>= 6.1)
+      bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.6)
+      strscan
+    rubocop (1.65.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.1)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    securerandom (0.3.1)
+    standard (1.40.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.65.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    timeout (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 7.2.0)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  mysql2 (~> 0.5)
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+
+BUNDLED WITH
+   2.5.14

--- a/gemfiles/rails7.2_trilogy.gemfile
+++ b/gemfiles/rails7.2_trilogy.gemfile
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec path: "../"
+
+gem "activerecord", "~> 7.2.0"
+gem "trilogy", ">= 2.5.0"
+
+eval_gemfile "common.rb"

--- a/gemfiles/rails7.2_trilogy.gemfile.lock
+++ b/gemfiles/rails7.2_trilogy.gemfile.lock
@@ -1,0 +1,121 @@
+PATH
+  remote: ..
+  specs:
+    active_record_host_pool (2.2.0)
+      activerecord (>= 6.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (7.2.1)
+      activesupport (= 7.2.1)
+    activerecord (7.2.1)
+      activemodel (= 7.2.1)
+      activesupport (= 7.2.1)
+      timeout (>= 0.4.0)
+    activesupport (7.2.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+    ast (2.4.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    byebug (11.1.3)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.4)
+    connection_pool (2.4.1)
+    drb (2.2.1)
+    i18n (1.14.5)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    lint_roller (1.1.0)
+    logger (1.6.0)
+    method_source (1.1.0)
+    minitest (5.25.1)
+    minitest-fail-fast (0.1.0)
+      minitest (~> 5)
+    minitest-line (0.6.5)
+      minitest (~> 5.0)
+    minitest-mock_expectations (1.2.0)
+    parallel (1.26.3)
+    parser (3.3.4.2)
+      ast (~> 2.4.1)
+      racc
+    phenix (1.4.0)
+      activerecord (>= 6.1)
+      bundler
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.6)
+      strscan
+    rubocop (1.65.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.1)
+      parser (>= 3.3.1.0)
+    rubocop-performance (1.21.1)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    securerandom (0.3.1)
+    standard (1.40.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.65.0)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.4)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.4.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.21.0)
+    strscan (3.1.0)
+    timeout (0.4.1)
+    trilogy (2.8.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  active_record_host_pool!
+  activerecord (~> 7.2.0)
+  minitest (>= 5.10.0)
+  minitest-fail-fast
+  minitest-line
+  minitest-mock_expectations
+  phenix (>= 1.0.1)
+  pry-byebug (~> 3.9)
+  rake (>= 12.0.0)
+  standard
+  trilogy (>= 2.5.0)
+
+BUNDLED WITH
+   2.5.14

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -8,7 +8,7 @@ when :trilogy
   when "6.1", "7.0"
     require "trilogy_adapter/connection"
     ActiveRecord::Base.extend(TrilogyAdapter::Connection)
-  when "7.1"
+  when "7.1", "7.2", "8.0"
     require "active_record/connection_adapters/trilogy_adapter"
   else
     raise "Unsupported version of Rails (v#{ActiveRecord::VERSION::STRING})"
@@ -89,9 +89,18 @@ module ActiveRecordHostPool
       _host_pool_desired_database != @_cached_current_database
     end
 
-    def _real_connection_object_id
-      @connection.object_id
+    # rubocop:disable Lint/DuplicateMethods
+    case "#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"
+    when "6.1", "7.0", "7.1"
+      def _real_connection_object_id
+        @connection.object_id
+      end
+    else
+      def _real_connection_object_id
+        @raw_connection.object_id
+      end
     end
+    # rubocop:enable Lint/DuplicateMethods
 
     def _real_connection_changed?
       _real_connection_object_id != @_cached_connection_object_id

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -101,8 +101,6 @@ module ActiveRecordHostPool
 
   module PoolConfigPatch
     def pool
-      ActiveSupport::ForkTracker.check!
-
       @pool || synchronize { @pool ||= ActiveRecordHostPool::PoolProxy.new(self) }
     end
   end

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -81,7 +81,7 @@ module ActiveRecordHostPool
           raw_connection.select_db(_host_pool_desired_database)
         end
         @_cached_current_database = _host_pool_desired_database
-        @_cached_connection_object_id = @connection.object_id
+        @_cached_connection_object_id = _real_connection_object_id
       end
     end
 
@@ -89,8 +89,12 @@ module ActiveRecordHostPool
       _host_pool_desired_database != @_cached_current_database
     end
 
+    def _real_connection_object_id
+      @connection.object_id
+    end
+
     def _real_connection_changed?
-      @connection.object_id != @_cached_connection_object_id
+      _real_connection_object_id != @_cached_connection_object_id
     end
 
     # prevent different databases from sharing the same query cache

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -26,6 +26,7 @@ class ActiveRecordHostCachingTest < Minitest::Test
   end
 
   def test_models_with_matching_hosts_and_non_matching_databases_issue_exists_without_arhp_patch
+    skip if ActiveRecord.version >= Gem::Version.new("7.2.0.a")
     # Reset the connections post-setup so that we ensure the last DB isn't arhp_test_db_c
     ActiveRecord::Base.connection.discard!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})


### PR DESCRIPTION
Add support for Rails 7.2 & main. See the individual commits for more details.

## Necessary changes:

### Rename `@connection` → `@raw_connection` adapter mixin.

`@connection` was renamed to `@raw_connection` on the database adapters
requiring us to conditionally define the `#_real_connection_object_id`
method. One returns `@connection.object_id` and the other
`@raw_connection.object_id`.

### Rename `#connection` → `#lease_connection` on the PoolProxy.

`#connection` was renamed to `#lease_connection` in Rails[^1]

### Refactor `#with_connection` on the PoolProxy.

`#with_connection` in Rails now leverages a new `ConnectionPool::Lease`
class[^2]. Essentially, the *real* connection pool has a connection
lease for the thread that may, or may not, have a **real** connection that may or
may not be "sticky". See the details about what that means in the Rails
commit. For ARHP purposes, we are essentially implementing the same
logic of `#with_connection` in Rails. We ask the real pool for its
`connection_lease`. We ask the lease for its **real** connection _or_
checkout a new **real** connection. Once we have a **real** connection we
yield a connection **proxy** for that **real** connection, checking it back
in unless the connection lease is "sticky".

### Memoize a PoolProxy in the `schema_cache`.

ConnectionPool passes itself to a `BoundSchemaReflection` which it
stores in its `@schema_cache` ivar[^3]. The pool is set as `@pool` on
the `BoundSchemaReflection` which will end up calling `with_connection`
on the pool[^4]. If this is a _real_ pool and not a PoolProxy we can end
up using the wrong database.

###  Skip the query cache patch test on Rails 7.2+. 

Clearing query caches no longer calls `.connection` and therefore this problem is fixed
in ARHP. `.connection` would make ARHP switch to different databases in
the middle of a database query resulting in us ending up on a database
other than the one we intended[^5].


[^1]:(https://github.com/rails/rails/commit/38e8609ded6cf01f6ed20b1134499e07cd68293f#diff-642b90553b888bd2c724c093a1a685a5408a7d8293f3751366c25dc548936eb7R290)

[^2]:(https://github.com/rails/rails/commit/38e8609ded6cf01f6ed20b1134499e07cd68293f#diff-642b90553b888bd2c724c093a1a685a5408a7d8293f3751366c25dc548936eb7R371)

[^3]:(https://github.com/rails/rails/blob/fa048105d145536538b923fa57465bdeee559e88/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb#L266)

[^4]:(https://github.com/rails/rails/blob/fa048105d145536538b923fa57465bdeee559e88/activerecord/lib/active_record/connection_adapters/schema_cache.rb#L320)

[^5]:(https://github.com/rails/rails/commit/e88dba8f0b7)