### PR TITLE
Call `#clean!` on the connection after switching, release v3.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Added
+- Calls `#clean!` on the connection after switching databases.
+
 ## [3.0.0]
 
 ### Added

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [3.1.0]
+
 ### Added
 - Calls `#clean!` on the connection after switching databases.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails6.1_mysql2.gemfile.lock
+++ b/gemfiles/rails6.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails6.1_trilogy.gemfile.lock
+++ b/gemfiles/rails6.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.0_mysql2.gemfile.lock
+++ b/gemfiles/rails7.0_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.1_mysql2.gemfile.lock
+++ b/gemfiles/rails7.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.1_trilogy.gemfile.lock
+++ b/gemfiles/rails7.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.2_mysql2.gemfile.lock
+++ b/gemfiles/rails7.2_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.2_trilogy.gemfile.lock
+++ b/gemfiles/rails7.2_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.0.0)
+    active_record_host_pool (3.1.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -79,6 +79,7 @@ module ActiveRecordHostPool
         log("select_db #{_host_pool_desired_database}", "SQL") do
           clear_cache!
           raw_connection.select_db(_host_pool_desired_database)
+          clean! if respond_to?(:clean)
         end
         @_cached_current_database = _host_pool_desired_database
         @_cached_connection_object_id = _real_connection_object_id

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Whenever you call `raw_connection` Rails sets `@raw_connection_dirty = true` on the connection[^1]. The consequence of this is that Rails will not automatically reconnect a dirty connection because `reconnect_can_restore_state?` will return `false`[^2] which will set `reconnectable` to `false`[^3].

There's a comment in Rails that explains why they "dirty" the connection
whenever you call `raw_connection`:

```
Active Record cannot track if the database is getting modified using
this client. If that is the case, generally you'll want to invalidate
the query cache using +ActiveRecord::Base.clear_query_cache+.
```

Basically, I think what this means is that Rails can't be sure you
haven't messed up your query caches and you should manually call
`clear_query_cache` after calling `raw_connection`. In ARHP we're
already clearing the cache just before we call
`raw_connection.select_db` so it should be safe to "clean" the
connection after.

[^1]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L788-L804)

[^2]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L946-L948)

[^3]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L991)