### PR TITLE
Call `#verified!` after cleaning, release v3.2.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [3.2.0]
+
 ### Added
 - Calls `#verified!` on the connection after `#clean!`.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,9 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Added
+- Calls `#verified!` on the connection after `#clean!`.
+
 ## [3.1.1]
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails6.1_mysql2.gemfile.lock
+++ b/gemfiles/rails6.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails6.1_trilogy.gemfile.lock
+++ b/gemfiles/rails6.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.0_mysql2.gemfile.lock
+++ b/gemfiles/rails7.0_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.1_mysql2.gemfile.lock
+++ b/gemfiles/rails7.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.1_trilogy.gemfile.lock
+++ b/gemfiles/rails7.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.2_mysql2.gemfile.lock
+++ b/gemfiles/rails7.2_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.2_trilogy.gemfile.lock
+++ b/gemfiles/rails7.2_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.1.1)
+    active_record_host_pool (3.2.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -79,7 +79,10 @@ module ActiveRecordHostPool
         log("select_db #{_host_pool_desired_database}", "SQL") do
           clear_cache!
           raw_connection.select_db(_host_pool_desired_database)
-          clean! if respond_to?(:clean!)
+          if respond_to?(:clean!)
+            clean!
+            verified!
+          end
         end
         @_cached_current_database = _host_pool_desired_database
         @_cached_connection_object_id = _real_connection_object_id

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "3.1.1"
+  VERSION = "3.2.0"
 end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -27,11 +27,20 @@ class ActiveRecordHostPoolTest < Minitest::Test
     ActiveRecord::Base.connection_handler.clear_all_connections!(:all)
   end
 
-  def tests_switching_databases_on_the_same_pool_produces_a_clean_connection
+  def test_switching_databases_on_the_same_pool_produces_a_clean_connection
     skip unless Pool1DbA.connection.respond_to?(:clean!)
-    Pool1DbA.connection.clean!
 
-    refute(Pool1DbB.connection.unproxied.instance_variable_get(:@raw_connection_dirty))
+    unproxied_connection = Pool1DbA.connection.unproxied
+
+    # Clean and verify the connection before we end up calling `raw_connection.select_db` again.
+    # We want to ensure that the connection stays clean and verified.
+    Pool1DbA.connection.clean!
+    Pool1DbA.connection.send(:verified!)
+
+    unproxied_connection.stub :verify!, -> { raise "`verify!` should not get called again" } do
+      assert(Pool1DbB.connection.unproxied.instance_variable_get(:@verified))
+      refute(Pool1DbB.connection.unproxied.instance_variable_get(:@raw_connection_dirty))
+    end
   end
 
   def test_models_with_matching_hosts_ports_sockets_usernames_and_replica_status_should_share_a_connection


### PR DESCRIPTION
I'm worried that calling `#clean!` will cause a performance hit. `#clean!`
will set `@raw_connection_dirty` to `false` but also set `@verified` to
`nil`[^1]. If `@verified` is `nil` then Rails may end up calling
`#verify!`[^2]. `#verify!` ends up calling `#active?` which will ping
the database[^3] causing another roundtrip.

Instead, I think we should call `#verified!` [^6] after cleaning so that
Rails doesn't have to re-verify for us. I believe this is safe because
the raw connection has to be verified before it's yielded to
`select_db`[^4] and if `select_db` ends up raising a connection-related
error then Rails will set `@verified` to `false` and `raise` [^5]

[^1]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L783-L786)

[^2]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L993-L1004)

[^3]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L108-L110)

[^4]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L993-L1012)

[^5]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1033-L1038)

[^6]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L1050-L1052)