### PR TITLE
Move _switch_connection into with_raw_connection

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,13 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+### Changed
+- Moved `select_db` inside of the `with_raw_connection` block of the `#raw_execute` method. This should allow for using Rails' built-in reconnect & retry logic with the Trilogy adapter or Rails 7.1+.
+- In Rails 7.1+, when a new ConnectionProxy is instantiated the database switch is lazily triggered by the subsequent database query instead of immediately.
+
+### Removed
+- Calling `#clean!` and `#verified!` on connections because it is no longer necessary.
+
 ## [3.2.0]
 
 ### Added

--- a/lib/active_record_host_pool/pool_proxy.rb
+++ b/lib/active_record_host_pool/pool_proxy.rb
@@ -219,12 +219,7 @@ module ActiveRecordHostPool
         @connection_proxy_cache ||= {}
         key = [connection, database]
 
-        @connection_proxy_cache[key] ||= begin
-          cx = ActiveRecordHostPool::ConnectionProxy.new(connection, database)
-          cx.raw_execute("SELECT 1", "ARHP SWITCH DB")
-
-          cx
-        end
+        @connection_proxy_cache[key] ||= ActiveRecordHostPool::ConnectionProxy.new(connection, database)
       end
     end
     # standard:enable Lint/DuplicateMethods

--- a/test/test_arhp_wrong_db.rb
+++ b/test/test_arhp_wrong_db.rb
@@ -15,7 +15,7 @@ class ActiveRecordHostPoolWrongDBTest < Minitest::Test
     Phenix.burn!
   end
 
-  # rake db:create uses a pattern where it tries to connect to a non-existant database.
+  # rake db:create uses a pattern where it tries to connect to a non-existent database.
   # but then we had this left in the connection pool cache.
   def test_connecting_to_wrong_db_first
     reached_first_exception = false
@@ -25,8 +25,9 @@ class ActiveRecordHostPoolWrongDBTest < Minitest::Test
       eval(<<-RUBY, binding, __FILE__, __LINE__ + 1)
         class TestNotThere < ActiveRecord::Base
           establish_connection(:test_pool_1_db_not_there)
-          connection
         end
+
+        TestNotThere.connection.execute("SELECT 1")
       RUBY
     rescue => e
       assert_match(/(Unknown database|We could not find your database:) '?arhp_test_db_not_there/, e.message)
@@ -38,7 +39,7 @@ class ActiveRecordHostPoolWrongDBTest < Minitest::Test
     TestNotThere.establish_connection(:test_pool_1_db_a)
 
     begin
-      TestNotThere.connection
+      TestNotThere.connection.execute("SELECT 1")
     rescue => e
       # If the pool is caching a bad connection, that connection will be used instead
       # of the intended connection.

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -147,30 +147,18 @@ class ThreadSafetyTest < Minitest::Test
   end
 
   def assert_query_host_1_db_a(sleep_time: 0)
-    result = if ActiveRecord.version >= Gem::Version.new("7.1") || ActiveRecordHostPool.loaded_db_adapter == :trilogy
-      Pool1DbA.connection.raw_execute("SELECT val, SLEEP(#{sleep_time}) from tests", nil)
-    else
-      Pool1DbA.connection.execute("SELECT val, SLEEP(#{sleep_time}) from tests")
-    end
-    assert_equal("test_Pool1DbA_value", result.first.first)
+    result = Pool1DbA.connection.query_value("SELECT val, SLEEP(#{sleep_time}) from tests")
+    assert_equal("test_Pool1DbA_value", result)
   end
 
   def assert_query_host_1_db_b(sleep_time: 0)
-    result = if ActiveRecord.version >= Gem::Version.new("7.1") || ActiveRecordHostPool.loaded_db_adapter == :trilogy
-      Pool1DbB.connection.raw_execute("SELECT val, SLEEP(#{sleep_time}) from tests", nil)
-    else
-      Pool1DbB.connection.execute("SELECT val, SLEEP(#{sleep_time}) from tests")
-    end
-    assert_equal("test_Pool1DbB_value", result.first.first)
+    result = Pool1DbB.connection.query_value("SELECT val, SLEEP(#{sleep_time}) from tests")
+    assert_equal("test_Pool1DbB_value", result)
   end
 
   def assert_query_host_2_db_d(sleep_time: 0)
-    result = if ActiveRecord.version >= Gem::Version.new("7.1") || ActiveRecordHostPool.loaded_db_adapter == :trilogy
-      Pool2DbD.connection.raw_execute("SELECT val, SLEEP(#{sleep_time}) from tests", nil)
-    else
-      Pool2DbD.connection.execute("SELECT val, SLEEP(#{sleep_time}) from tests")
-    end
-    assert_equal("test_Pool2DbD_value", result.first.first)
+    result = Pool2DbD.connection.query_value("SELECT val, SLEEP(#{sleep_time}) from tests")
+    assert_equal("test_Pool2DbD_value", result)
   end
 
   def checkin_connection


### PR DESCRIPTION
Right now `ActiveRecordHostPool` never makes it into ActiveRecord's reconnect/retry logic. That's because that logic starts inside of the `#with_raw_connection` method[^1]. Here's a simplified look at the method:

```ruby
def with_raw_connection(allow_retry: false, materialize_transactions: true)
  # ...
  begin
    yield @raw_connection # <-- The raw connection is yielded to the block.
  rescue => exception
    # ...
    if reconnectable && retryable_connection_error?(exception)
      # Reconnect & retry certain errors.
      reconnect!
      retry
    end
  end
end
```

In host pool we patch `#raw_execute` to conduct the database switch:

```ruby
def raw_execute(...)
  if _host_pool_desired_database && !_no_switch
    _switch_connection
  end
  super
end
```

`#raw_execute` in Rails wraps the query in `#with_raw_connection` and
thus that's where we get the reconnect behavior:

```ruby
def raw_execute(sql, name, async: false, allow_retry: false, materialize_transactions: true)
  # ...
  with_raw_connection(allow_retry: allow_retry, materialize_transactions: materialize_transactions) do |conn|
    result = conn.query(sql)
  end
  # ...
end
```

Because we're attempting to switch databases outside of the `#with_raw_connection`, if that database switch fails then we won't reconnect or retry.

A better solution would be to instead patch `#with_raw_connection`. Because that method yields the `raw_connection` (which we use to call `select_db` on) we can patch it so that we call `select_db` on the yielded raw connection first and then execute the rest of the block.

An added bonus to this is that we're no longer calling `#raw_connection` anywhere. `#raw_connection` would mark the connection "dirty"[^2] forcing us to `#clean!` and verify it every time. We're using the `raw_connection` that's yielded by `#with_raw_connection` keeps the connection "clean".

Three other notes:

When we instantiate a `ConnectionProxy` we used to call `raw_execute("SELECT 1")` to trigger a database switch. I removed that because `raw_execute` is where we pass `allow_retry` and I don't think ActiveRecordHostPool should make a decision about if we're allowing retries or not. So
instead of instantiating a `ConnectionProxy` and immediately forcing a `select_db` we wait to switch databases until the first time `with_raw_connection` is called.

Related to the above: `test_arhp_wrong_db.rb` is updated to call `TestNotThere.connection.execute("SELECT 1")` instead of just `TestNotThere.connection`. Now that we're lazily switching databases we don't trigger a `SELECT 1` call just by instantiating a new connection. This means we have to explicitly trigger a database query in this test.

In `test_thread_safety.rb` we would conditionally call `#connection.raw_execute(...).first.first` or `#connection.execute(...).first.first` depending on what version of Rails and which adapter we're using. That's because, depending on the implementation, `execute` would either return the value returned from the query _or_ an array with the column name and the returned value. Because we only care about the value in these tests I've changed it so that we call `connection.query_value(...)` which does exactly what we want.

[^1]:(https://github.com/rails/rails/blob/a86a88965bfa4d596156b08901164be2f0d0da6c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L975-L1004)

[^2]:(https://github.com/rails/rails/blob/a86a88965bfa4d596156b08901164be2f0d0da6c/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb#L790-L796)