### PR TITLE
Release v4.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@ and as of v1.0.0 this project adheres to [Semantic Versioning](https://semver.or
 
 ## [Unreleased]
 
+## [4.0.0]
+
 ### Changed
 - Moved `select_db` inside of the `with_raw_connection` block of the `#raw_execute` method. This should allow for using Rails' built-in reconnect & retry logic with the Trilogy adapter or Rails 7.1+.
 - In Rails 7.1+, when a new ConnectionProxy is instantiated the database switch is lazily triggered by the subsequent database query instead of immediately.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails6.1_mysql2.gemfile.lock
+++ b/gemfiles/rails6.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails6.1_trilogy.gemfile.lock
+++ b/gemfiles/rails6.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.0_mysql2.gemfile.lock
+++ b/gemfiles/rails7.0_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.0_trilogy.gemfile.lock
+++ b/gemfiles/rails7.0_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.1_mysql2.gemfile.lock
+++ b/gemfiles/rails7.1_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.1_trilogy.gemfile.lock
+++ b/gemfiles/rails7.1_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.2_mysql2.gemfile.lock
+++ b/gemfiles/rails7.2_mysql2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails7.2_trilogy.gemfile.lock
+++ b/gemfiles/rails7.2_trilogy.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    active_record_host_pool (3.2.0)
+    active_record_host_pool (4.0.0)
       activerecord (>= 6.1.0)
 
 GEM

--- a/lib/active_record_host_pool/version.rb
+++ b/lib/active_record_host_pool/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActiveRecordHostPool
-  VERSION = "3.2.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
\### Changed
- Moved `select_db` inside of the `with_raw_connection` block of the `#raw_execute` method. This should allow for using Rails' built-in reconnect & retry logic with the Trilogy adapter or Rails 7.1+.
- In Rails 7.1+, when a new ConnectionProxy is instantiated the database switch is lazily triggered by the subsequent database query instead of immediately.

\### Removed
- Calling `#clean!` and `#verified!` on connections because it is no longer necessary.