### PR TITLE
Rails main branch is now 8.1.0.alpha

### DIFF
--- a/lib/active_record_host_pool/connection_adapter_mixin.rb
+++ b/lib/active_record_host_pool/connection_adapter_mixin.rb
@@ -8,7 +8,7 @@ when :trilogy
   when "6.1", "7.0"
     require "trilogy_adapter/connection"
     ActiveRecord::Base.extend(TrilogyAdapter::Connection)
-  when "7.1", "7.2", "8.0"
+  when "7.1", "7.2", "8.0", "8.1"
     require "active_record/connection_adapters/trilogy_adapter"
   else
     raise "Unsupported version of Rails (v#{ActiveRecord::VERSION::STRING})"


### PR DESCRIPTION
This may fix our test runs using the Rails `main` branch.