### PR TITLE
Delete all records instead of dropping dbs

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -45,6 +45,21 @@ require_relative "models"
 module ARHPTestSetup
   private
 
+  def delete_all_records
+    Pool1DbC.delete_all
+    Pool1DbA.delete_all
+    Pool1DbAOther.delete_all
+    Pool1DbB.delete_all
+    Pool2DbD.delete_all
+    Pool2DbE.delete_all
+    Pool3DbE.delete_all
+
+    AbstractShardedModel.connected_to(shard: :default, role: :writing) { ShardedModel.delete_all }
+    AbstractShardedModel.connected_to(shard: :shard_b, role: :writing) { ShardedModel.delete_all }
+    AbstractShardedModel.connected_to(shard: :shard_c, role: :writing) { ShardedModel.delete_all }
+    AbstractShardedModel.connected_to(shard: :shard_b, role: :writing) { ShardedModel.delete_all }
+  end
+
   def current_database(klass)
     klass.connection.select_value("select DATABASE()")
   end

--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -4,18 +4,16 @@ require_relative "helper"
 
 class ActiveRecordHostPoolTest < Minitest::Test
   include ARHPTestSetup
-  def setup
-    Phenix.rise! config_path: "test/three_tier_database.yml"
-  end
 
   def teardown
+    delete_all_records
     ActiveRecord::Base.connection.disconnect!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
-    Phenix.burn!
   end
 
   def test_process_forking_with_connections
     # Ensure we have a connection already
+    ActiveRecord::Base.connection.execute("SELECT 1")
     assert_equal(true, ActiveRecord::Base.connected?)
 
     # Verify that when we fork, the process doesn't crash

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -4,14 +4,11 @@ require_relative "helper"
 
 class ActiveRecordHostCachingTest < Minitest::Test
   include ARHPTestSetup
-  def setup
-    Phenix.rise! config_path: "test/three_tier_database.yml"
-  end
 
   def teardown
+    delete_all_records
     ActiveRecord::Base.connection.disconnect!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
-    Phenix.burn!
   end
 
   def test_should_not_share_a_query_cache

--- a/test/test_arhp_connection_handling.rb
+++ b/test/test_arhp_connection_handling.rb
@@ -5,14 +5,11 @@ require "stringio"
 
 class ActiveRecordHostPoolTestWithNonlegacyConnectionHandling < Minitest::Test
   include ARHPTestSetup
-  def setup
-    Phenix.rise! config_path: "test/three_tier_database.yml"
-  end
 
   def teardown
+    delete_all_records
     ActiveRecord::Base.connection.disconnect!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
-    Phenix.burn!
   end
 
   def test_correctly_writes_to_sharded_databases_and_only_switches_dbs_when_necessary

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -7,17 +7,15 @@ class ThreadSafetyTest < Minitest::Test
   include ARHPTestSetup
 
   def setup
-    Phenix.rise! config_path: "test/three_tier_database.yml"
-
     Pool1DbA.create!(val: "test_Pool1DbA_value")
     Pool1DbB.create!(val: "test_Pool1DbB_value")
     Pool2DbD.create!(val: "test_Pool2DbD_value")
   end
 
   def teardown
+    delete_all_records
     ActiveRecord::Base.connection.disconnect!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
-    Phenix.burn!
   end
 
   def test_main_and_spawned_thread_switch_db_when_querying_same_host


### PR DESCRIPTION
We have a race condition that makes some of our tests flaky.

Previously we would call `Phenix.burn!` after _each_ test to drop all of the databases and then recreate them after. This cleared all of the records but also helped us with some tests where we expected some databases to not exist.

The problem with this is that ActiveRecord's connection pool reaper will, by default, start to kill connections after they're idle for 60 seconds and then reconnect[^1]. It also does this in a thread [^2].

What used to occasionally happen is that the reaper would kill a connection and then attempt to reconnect to the database _in between test runs_. i.e. _after_ the databases were dropped but _before_ they were created again. This would blow up.

This commit changes it so we no longer drop the databases but instead call `delete_all` on every model.

This required some other changes:

1. Call `ActiveRecord::Base.connection.execute(...)` in `test_arhp.rb` to ensure we've established a connection before we assert that it's connected. (Phenix.rise! would establish a connection previously and we intentionally call `disconnect!` after each test).
2. Update the `test_arhp_wrong_db.rb` tests to use configurations with the right credentials but made up database names so that we raise "database not found" errors. We used to drop all of the databases before this test but now we don't.

[^1]:(https://github.com/rails/rails/blob/a86a88965bfa4d596156b08901164be2f0d0da6c/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb#L15-L16)

[^2]:(https://github.com/rails/rails/blob/a86a88965bfa4d596156b08901164be2f0d0da6c/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb#L42)