### PR TITLE
Switch to trusted publishing workflow and run it on version.rb changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,3 +23,7 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - uses: rubygems/release-gem@v1
+      - name: Summary
+        run:
+          new_gem_tag="$(ruby -r "bundler" -e 'puts Bundler::GemHelper.new.send(:version_tag)')"
+          echo "**$new_gem_tag** published to Artifactory :rocket:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,25 @@
-name: Publish Gem
+name: Publish to RubyGems.org
 
 on:
   push:
-    tags: v*
+    branches: main
+    paths: lib/active_record_host_pool/version.rb
+  workflow_dispatch:
 
 jobs:
-  call-workflow:
-    uses: zendesk/gw/.github/workflows/ruby-gem-publication.yml@main
-    secrets:
-      RUBY_GEMS_API_KEY: ${{ secrets.RUBY_GEMS_API_KEY }}
-      RUBY_GEMS_TOTP_DEVICE: ${{ secrets.RUBY_GEMS_TOTP_DEVICE }}
+  publish:
+    runs-on: ubuntu-latest
+    environment: rubygems-publish
+    if: github.repository_owner == 'zendesk'
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: false
+      - name: Install dependencies
+        run: bundle install
+      - uses: rubygems/release-gem@v1

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,7 @@
 require "bundler/setup"
-require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"
 require "standard/rake"
-
-# Pushing to rubygems is handled by a github workflow
-ENV["gem_push"] = "false"
 
 Rake::TestTask.new do |test|
   test.pattern = "test/test_*.rb"

--- a/Readme.md
+++ b/Readme.md
@@ -50,7 +50,7 @@ Postgres, from an informal reading of the docs, will never support the concept o
 
     $ gem install active_record_host_pool
 
-and make sure to require 'active\_record\_host\_pool' in some way.
+and make sure to require 'active_record_host_pool' in some way.
 
 ## Testing
 You need a local user called 'john-doe'.
@@ -67,6 +67,21 @@ With mysql running locally, run
  Or
 
     BUNDLE_GEMFILE=gemfiles/rails6.1.gemfile ruby test/test_arhp.rb --seed 19911 --verbose
+
+### Releasing a new version
+A new version is published to RubyGems.org every time a change to `version.rb` is pushed to the `main` branch.
+In short, follow these steps:
+1. Update `version.rb`,
+2. update version in all `Gemfile.lock` files,
+3. merge this change into `main`, and
+4. look at [the action](https://github.com/zendesk/active_record_host_pool/actions/workflows/publish.yml) for output.
+
+To create a pre-release from a non-main branch:
+1. change the version in `version.rb` to something like `1.2.0.pre.1` or `2.0.0.beta.2`,
+2. push this change to your branch,
+3. go to [Actions → “Publish to RubyGems.org” on GitHub](https://github.com/zendesk/active_record_host_pool/actions/workflows/publish.yml),
+4. click the “Run workflow” button,
+5. pick your branch from a dropdown.
 
 ## Copyright
 


### PR DESCRIPTION
Switches to [a Trusted Publishing workflow](https://guides.rubygems.org/trusted-publishing/).
This workflow will run whenever `version.rb` is changed in the `main` branch.
Since the workflow loads `bundler/gem_tasks` explicitly, we don’t need to do that in the Rakefile (but we want to ensure that `bundler/setup` is present there).
Setting `ENV["gem_push"]` is also not necessary anymore.

`bundler-cache` for `setup-ruby` is set to false to prevent [cache poisoning attacks](https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/).
Finally, we add a description of the new release process. Our README and CONTRIBUTING files don’t have a standard structure, so please check that we have updated a correct file and that the new section makes sense for this gem.
- [ ] Release description has been updated correctly.