### PR TITLE
Fix flaky test

### DIFF
--- a/test/test_arhp.rb
+++ b/test/test_arhp.rb
@@ -7,7 +7,6 @@ class ActiveRecordHostPoolTest < Minitest::Test
 
   def teardown
     delete_all_records
-    ActiveRecord::Base.connection.disconnect!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 
@@ -175,8 +174,14 @@ class ActiveRecordHostPoolTest < Minitest::Test
     assert(c2 == connection)
   end
 
-  def test_no_switch_when_creating_db
+  def test_no_switch_when_creating_db_foo
+    # Ensure we have a connection already established.
+    Pool1DbA.connection.reconnect!
+
+    assert Pool1DbA.connected?
+
     conn = Pool1DbA.connection
+
     assert_called(conn, :raw_execute) do
       refute_called(conn, :_switch_connection) do
         assert conn._host_pool_desired_database

--- a/test/test_arhp_caching.rb
+++ b/test/test_arhp_caching.rb
@@ -7,7 +7,6 @@ class ActiveRecordHostCachingTest < Minitest::Test
 
   def teardown
     delete_all_records
-    ActiveRecord::Base.connection.disconnect!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 

--- a/test/test_arhp_connection_handling.rb
+++ b/test/test_arhp_connection_handling.rb
@@ -8,7 +8,6 @@ class ActiveRecordHostPoolTestWithNonlegacyConnectionHandling < Minitest::Test
 
   def teardown
     delete_all_records
-    ActiveRecord::Base.connection.disconnect!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 

--- a/test/test_thread_safety.rb
+++ b/test/test_thread_safety.rb
@@ -14,7 +14,6 @@ class ThreadSafetyTest < Minitest::Test
 
   def teardown
     delete_all_records
-    ActiveRecord::Base.connection.disconnect!
     ActiveRecordHostPool::PoolProxy.class_variable_set(:@@_connection_pools, {})
   end
 


### PR DESCRIPTION
After some tests we clear all of the active connections[^1] just in case. Because of this, we might begin a test without an active connection and thus Rails will need to reconnect and call `_switch_connection`. That breaks tests that expect `_switch_connection` doesn't get called.

[^1]:(https://github.com/zendesk/active_record_host_pool/blob/327e0dbf2fe50192129755997e4e05e1f915d07c/test/test_arhp.rb#L24-L25)