### PR TITLE
Add ruby-version to setup-ruby

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.2"
           bundler-cache: false
       - name: Install dependencies
         run: bundle install


### PR DESCRIPTION
We don't have a `.ruby-version` file so we need to set the `ruby-version` in the action.