### PR TITLE
require gem_tasks in rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require "bundler/gem_tasks"
 require "rake/testtask"
 require "rubocop/rake_task"
 require "standard/rake"


### PR DESCRIPTION
Otherwise, we don’t have a `release` task when we try to publish the gem.